### PR TITLE
fix: Update CI workflow to trigger on both main and dev branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,9 @@ name: Lint with Biome
 
 # このワークフローが実行されるタイミング
 on:
-  # devブランチに対してプルリクエストが開かれたり、更新された時
+  # mainとdevブランチに対してプルリクエストが開かれたり、更新された時
   pull_request:
-    branches: [dev] # 👈 ここを修正！
+    branches: [main, dev]
 
 # 実行される具体的な仕事（ジョブ）
 jobs:


### PR DESCRIPTION
- Add main branch to pull_request triggers to ensure CI runs for main branch PRs
- This fixes GitHub branch protection rule requiring status checks

🤖 Generated with [Claude Code](https://claude.ai/code)