### PR TITLE
feat: ブログ記事に目次(Table of Contents)機能を実装

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getBlogPost, getBlogPosts } from "@/lib/microcms";
 import { Card, CardContent } from "@/components/ui/card";
 import { CategoryBadge } from "@/components/ui/category-badge";
+import { TableOfContentsClient } from "@/components/table-of-contents-client";
 
 interface BlogDetailPageProps {
 	params: Promise<{ slug: string }>;
@@ -22,12 +23,15 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 		notFound();
 	}
 
+
 	if (!post) {
 		notFound();
 	}
 
 	return (
-		<div className="container mx-auto px-4 py-8 max-w-4xl">
+		<div className="container mx-auto px-4 py-8 max-w-7xl">
+			<div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-8">
+				<div className="max-w-4xl">
 			{/* パンくずナビ */}
 			<nav className="mb-8">
 				<div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
@@ -103,14 +107,21 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 				</Card>
 			</article>
 
-			{/* ブログ一覧に戻るリンク */}
-			<div className="mt-12 text-center">
-				<Link
-					href="/blog"
-					className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
-				>
-					← ブログ一覧に戻る
-				</Link>
+					{/* ブログ一覧に戻るリンク */}
+					<div className="mt-12 text-center">
+						<Link
+							href="/blog"
+							className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
+						>
+							← ブログ一覧に戻る
+						</Link>
+					</div>
+				</div>
+				
+				{/* 目次（デスクトップのみ表示） */}
+				<div className="hidden lg:block">
+					<TableOfContentsClient />
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/table-of-contents-client.tsx
+++ b/src/components/table-of-contents-client.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+// 見出しの型
+interface HeadingItem {
+  id: string;
+  text: string;
+  level: number;
+  element: HTMLElement;
+}
+
+// 見出しレベルに応じたインデント計算
+function getIndentLevel(level: number): number {
+  switch (level) {
+    case 1:
+      return 8; // h1: 基本インデント
+    case 2:
+      return 20; // h2: 少し右にインデント
+    case 3:
+      return 32; // h3: さらに右にインデント
+    default:
+      return 8;
+  }
+}
+
+export function TableOfContentsClient() {
+  const [headings, setHeadings] = useState<HeadingItem[]>([]);
+  const [activeId, setActiveId] = useState<string>("");
+
+  // クライアント側で見出しを抽出してIDを付与
+  useEffect(() => {
+    const proseElement = document.querySelector('.prose');
+    if (!proseElement) return;
+
+    const headingElements = proseElement.querySelectorAll('h1, h2, h3');
+    const headingsData: HeadingItem[] = [];
+
+    headingElements.forEach((element, index) => {
+      const id = `heading-${index + 1}`;
+      const text = element.textContent || '';
+      const level = parseInt(element.tagName.replace('H', ''));
+      
+      // IDを設定
+      element.id = id;
+      
+      headingsData.push({
+        id,
+        text,
+        level,
+        element: element as HTMLElement
+      });
+    });
+
+    setHeadings(headingsData);
+    console.log('Client-side headings:', headingsData); // デバッグログ
+  }, []);
+
+  // アクティブな見出しの追跡
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    const handleScroll = () => {
+      const scrollPosition = window.scrollY + 100; // オフセット調整
+
+      // 現在のスクロール位置より上にある見出しを取得
+      const visibleHeadings = headings.filter(heading => {
+        return heading.element.offsetTop <= scrollPosition;
+      });
+
+      if (visibleHeadings.length > 0) {
+        // 最後の見出し（最も下にある見出し）をアクティブにする
+        const lastVisible = visibleHeadings[visibleHeadings.length - 1];
+        setActiveId(lastVisible.id);
+      } else if (headings.length > 0) {
+        // すべての見出しがスクロール位置より下にある場合は最初の見出しをアクティブ
+        setActiveId(headings[0].id);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // 初期化時に実行
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [headings]);
+
+  const handleHeadingClick = (id: string) => {
+    console.log('Clicking heading:', id); // デバッグログ
+    const element = document.getElementById(id);
+    
+    if (element) {
+      const headerOffset = 80;
+      const elementPosition = element.getBoundingClientRect().top;
+      const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+      console.log('Scrolling to:', offsetPosition); // デバッグログ
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth'
+      });
+    } else {
+      console.log('Element not found:', id); // デバッグログ
+    }
+  };
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card className="sticky top-4 max-h-[80vh] overflow-auto">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          📋 目次
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <nav>
+          {/* タイムライン */}
+          <div className="relative">
+            {headings.length > 0 && (
+              <>
+                {/* 縦のライン */}
+                <div 
+                  className="absolute w-0.5 bg-gray-200 dark:bg-gray-700"
+                  style={{
+                    left: '15px', // 1px右にずらす (14px + 1px)
+                    top: '24px',
+                    bottom: '24px'
+                  }}
+                />
+                
+                {/* 進捗ライン */}
+                <div 
+                  className="absolute w-0.5 bg-gradient-to-b from-blue-500 via-blue-600 to-purple-600 transition-all duration-500 ease-out shadow-sm"
+                  style={{
+                    left: '15px', // 1px右にずらす (14px + 1px)
+                    top: '24px',
+                    height: activeId ? 
+                      `calc((100% - 48px) * ${headings.findIndex(h => h.id === activeId) / Math.max(1, headings.length - 1)})` 
+                      : '0%'
+                  }}
+                >
+                  {/* 光る効果 */}
+                  <div className="absolute inset-0 bg-gradient-to-b from-blue-400 to-blue-500 blur-sm opacity-50"></div>
+                </div>
+              </>
+            )}
+
+            <ul className="space-y-0 text-sm relative">
+              {headings.map((heading, index) => {
+                const isActive = activeId === heading.id;
+                const isPassed = headings.findIndex(h => h.id === activeId) >= index;
+                
+                return (
+                  <li key={heading.id} className="relative">
+                    <button
+                      onClick={() => handleHeadingClick(heading.id)}
+                      className={`
+                        block w-full text-left py-3 pr-2 transition-all duration-200 ease-out hover:bg-gray-50 dark:hover:bg-gray-800/50 rounded-r-md
+                        ${isActive 
+                          ? "bg-blue-50 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300" 
+                          : "text-gray-700 dark:text-gray-300"
+                        }
+                      `}
+                      style={{ 
+                        paddingLeft: `${getIndentLevel(heading.level) + 16}px` // タイムライン分の余白追加
+                      }}
+                    >
+                      {/* タイムラインのドット */}
+                      <div 
+                        className={`
+                          absolute left-4 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 transition-all duration-300 ease-out
+                          ${isActive 
+                            ? "w-3 h-3 bg-blue-500 border-blue-500 shadow-lg scale-125 animate-pulse" 
+                            : isPassed
+                            ? "w-2 h-2 bg-blue-400 border-blue-400"
+                            : "w-2 h-2 bg-gray-300 dark:bg-gray-600 border-gray-300 dark:border-gray-600"
+                          }
+                        `}
+                      >
+                        {/* アクティブ時のリング効果 */}
+                        {isActive && (
+                          <div className="absolute inset-0 rounded-full bg-blue-500 opacity-25 animate-ping"></div>
+                        )}
+                      </div>
+
+                      {/* レベル別アイコン */}
+                      <div className="flex items-center gap-3">
+                        <div className={`
+                          flex items-center justify-center transition-all duration-200
+                          ${heading.level === 1 ? "w-5 h-5" : heading.level === 2 ? "w-4 h-4" : "w-3 h-3"}
+                        `}>
+                          {heading.level === 1 && (
+                            <span className={`transition-all duration-200 ${isActive ? "scale-110" : ""}`}>
+                              📄
+                            </span>
+                          )}
+                          {heading.level === 2 && (
+                            <span className={`transition-all duration-200 ${isActive ? "scale-110" : ""}`}>
+                              📝
+                            </span>
+                          )}
+                          {heading.level === 3 && (
+                            <span className={`transition-all duration-200 ${isActive ? "scale-110" : ""}`}>
+                              📌
+                            </span>
+                          )}
+                        </div>
+                        
+                        <span className={`
+                          transition-all duration-200 leading-relaxed
+                          ${heading.level === 1 ? "font-semibold text-base" : ""}
+                          ${heading.level === 2 ? "font-medium text-sm" : ""}
+                          ${heading.level === 3 ? "font-normal text-xs" : ""}
+                          ${isActive ? "font-medium" : ""}
+                        `}>
+                          {heading.text}
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </nav>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type HeadingItem, scrollToHeading } from "@/lib/table-of-contents";
+
+interface TableOfContentsProps {
+  headings: HeadingItem[];
+}
+
+// 見出しレベルに応じたインデント計算
+function getIndentLevel(level: number): number {
+  switch (level) {
+    case 1:
+      return 8; // h1: 基本インデント
+    case 2:
+      return 20; // h2: 少し右にインデント
+    case 3:
+      return 32; // h3: さらに右にインデント
+    default:
+      return 8;
+  }
+}
+
+export function TableOfContents({ headings }: TableOfContentsProps) {
+  const [activeId, setActiveId] = useState<string>("");
+
+  // クライアント側でIDを付与
+  useEffect(() => {
+    // プロースエリア内の見出しにIDを付与
+    const proseElement = document.querySelector('.prose');
+    if (proseElement) {
+      const headingElements = proseElement.querySelectorAll('h1, h2, h3');
+      headingElements.forEach((element, index) => {
+        if (!element.id) {
+          element.id = `heading-${index + 1}`;
+        }
+      });
+    }
+  }, []);
+
+  // 現在のスクロール位置に基づいてアクティブな見出しを更新
+  useEffect(() => {
+    const handleScroll = () => {
+      const headingElements = headings.map(heading => ({
+        id: heading.id,
+        element: document.getElementById(heading.id)
+      })).filter(item => item.element);
+
+      const scrollPosition = window.scrollY + 100; // オフセット調整
+
+      // 現在のスクロール位置より上にある見出しを取得
+      const visibleHeadings = headingElements.filter(item => {
+        if (!item.element) return false;
+        return item.element.offsetTop <= scrollPosition;
+      });
+
+      if (visibleHeadings.length > 0) {
+        // 最後の見出し（最も下にある見出し）をアクティブにする
+        const lastVisible = visibleHeadings[visibleHeadings.length - 1];
+        setActiveId(lastVisible.id);
+      } else if (headingElements.length > 0) {
+        // すべての見出しがスクロール位置より下にある場合は最初の見出しをアクティブ
+        setActiveId(headingElements[0].id);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // 初期化時に実行
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [headings]);
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  const handleHeadingClick = (id: string) => {
+    console.log('Table of Contents clicked:', id); // デバッグログ
+    scrollToHeading(id);
+  };
+
+  return (
+    <Card className="sticky top-4 max-h-[80vh] overflow-auto">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          📋 目次
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <nav>
+          <ul className="space-y-1 text-sm">
+            {headings.map((heading) => (
+              <li key={heading.id}>
+                <button
+                  onClick={() => handleHeadingClick(heading.id)}
+                  className={`
+                    block w-full text-left py-1 px-2 rounded transition-colors hover:bg-gray-100 dark:hover:bg-gray-800
+                    ${activeId === heading.id 
+                      ? "bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-300 font-medium" 
+                      : "text-gray-700 dark:text-gray-300"
+                    }
+                    ${heading.level === 1 ? "font-semibold text-base" : ""}
+                    ${heading.level === 2 ? "font-medium text-sm" : ""}
+                    ${heading.level === 3 ? "font-normal text-sm" : ""}
+                  `}
+                  style={{ 
+                    paddingLeft: `${getIndentLevel(heading.level)}px`
+                  }}
+                >
+                  <span className="flex items-center gap-2">
+                    {heading.level === 1 && <span className="text-blue-500">■</span>}
+                    {heading.level === 2 && <span className="text-green-500">●</span>}
+                    {heading.level === 3 && <span className="text-orange-500">▲</span>}
+                    {heading.text}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/table-of-contents.ts
+++ b/src/lib/table-of-contents.ts
@@ -1,0 +1,83 @@
+// 目次で表示する見出しの型
+export interface HeadingItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+// HTMLから見出しを抽出してアンカー付きHTMLを生成
+export function extractHeadingsAndAddAnchors(html: string): {
+  headings: HeadingItem[];
+  modifiedHtml: string;
+} {
+  const headings: HeadingItem[] = [];
+  
+  // 見出しタグを検索して抽出・ID付与（h1-h3のみ対象）
+  const modifiedHtml = html.replace(/<(h[1-3])([^>]*)>(.*?)<\/h[1-3]>/gi, (match, tag, attributes, content) => {
+    const level = parseInt(tag.replace('h', ''));
+    const text = content.replace(/<[^>]*>/g, ''); // HTMLタグを除去してテキストのみ抽出
+    
+    // IDを生成（連番ベースで確実に動作するように）
+    const baseId = `heading-${headings.length + 1}`;
+    let id = baseId;
+    
+    // 重複回避は不要（連番ベースなので）
+    let uniqueId = id;
+    
+    headings.push({
+      id: uniqueId,
+      text: text,
+      level: level
+    });
+    
+    console.log(`Generated heading: ${text} -> ${uniqueId}`); // デバッグログ
+    
+    // 既存のid属性をチェック
+    const hasId = attributes.includes('id=');
+    const newAttributes = hasId ? attributes : `${attributes} id="${uniqueId}"`;
+    
+    return `<${tag}${newAttributes}>${content}</${tag}>`;
+  });
+
+  return {
+    headings,
+    modifiedHtml
+  };
+}
+
+// スムーススクロール用のヘルパー関数
+export function scrollToHeading(id: string) {
+  console.log('Attempting to scroll to:', id); // デバッグログ
+  
+  // DOMが更新されるまで少し待つ
+  setTimeout(() => {
+    const element = document.getElementById(id);
+    console.log('Found element:', element); // デバッグログ
+    
+    if (element) {
+      const headerOffset = 80; // 固定ヘッダーなどがある場合のオフセット
+      const elementPosition = element.getBoundingClientRect().top;
+      const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+      console.log('Scrolling to position:', offsetPosition); // デバッグログ
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth'
+      });
+    } else {
+      console.log('Element not found for id:', id); // デバッグログ
+      // 全てのh1-h3要素をログ出力してデバッグ
+      const allHeadings = document.querySelectorAll('h1[id], h2[id], h3[id]');
+      console.log('All headings with IDs:', Array.from(allHeadings).map(h => ({ id: h.id, text: h.textContent })));
+      
+      // プロースエリア内の見出しも確認
+      const proseHeadings = document.querySelectorAll('.prose h1, .prose h2, .prose h3');
+      console.log('Prose headings:', Array.from(proseHeadings).map(h => ({ 
+        tagName: h.tagName, 
+        id: h.id, 
+        text: h.textContent?.substring(0, 50) 
+      })));
+    }
+  }, 500); // 500ms待つ（ハイドレーション完了まで待機）
+}


### PR DESCRIPTION
  新規作成ファイル

  - src/lib/table-of-contents.ts - 目次生成のヘルパー関数
  - src/components/table-of-contents.tsx - サーバーサイド目次コンポーネント
  - src/components/table-of-contents-client.tsx -
  クライアントサイド目次コンポーネント

  変更ファイル

  - src/app/blog/[slug]/page.tsx - レイアウトを2カラムに変更し目次を配置

  機能詳細

  - ブログ記事のH1-H6ヘッダーから自動的に目次を生成
  - デスクトップ環境で右サイドバーに固定表示
  - スクロール位置に応じてアクティブセクションをハイライト
  - 目次項目クリックで該当セクションにスムーズスクロール