### PR TITLE
 fix: 募集要項ページのダークモードUIを統一

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(git merge:*)",
       "Bash(pnpm dlx:*)",
       "Bash(pnpm prisma generate:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(rm:*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,6 +72,12 @@ html.dark [data-card="blog-card"] {
 	background-color: white !important;
 }
 
+/* Remove any gradient backgrounds from blog cards */
+[data-card="blog-card"],
+html.dark [data-card="blog-card"] {
+	background-image: none !important;
+}
+
 /* 3D Flip Animation Styles */
 .perspective-1000 {
 	perspective: 1000px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,6 +78,17 @@ html.dark [data-card="blog-card"] {
 	background-image: none !important;
 }
 
+/* Force white background for all elements inside blog cards */
+[data-card="blog-card"] div,
+[data-card="blog-card"] p,
+[data-card="blog-card"] span,
+html.dark [data-card="blog-card"] div,
+html.dark [data-card="blog-card"] p,
+html.dark [data-card="blog-card"] span {
+	background-color: white !important;
+	background-image: none !important;
+}
+
 /* 3D Flip Animation Styles */
 .perspective-1000 {
 	perspective: 1000px;

--- a/src/components/blog/application-form.tsx
+++ b/src/components/blog/application-form.tsx
@@ -78,7 +78,7 @@ export function ApplicationForm({ onSubmit }: ApplicationFormProps) {
   };
 
   return (
-    <Card className="border-2 border-blue-200 dark:border-blue-800">
+    <Card className="border-2 border-blue-200">
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Mail className="w-5 h-5" />

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -135,8 +135,8 @@ export function BlogCard({ post }: BlogCardProps) {
                 color: "rgb(3 7 18) !important",
               }}
             >
-              <div className="flex flex-col h-full p-6">
-                <div className="flex-shrink-0 mb-4">
+              <div className="flex flex-col h-full p-6 bg-white">
+                <div className="flex-shrink-0 mb-4 bg-white">
                   <h3 className="text-lg line-clamp-2 text-gray-800 dark:text-gray-800 font-semibold mb-3 leading-tight">
                     {post.title}
                   </h3>
@@ -155,13 +155,13 @@ export function BlogCard({ post }: BlogCardProps) {
                   </div>
                 </div>
 
-                <div className="flex-grow flex flex-col justify-center mb-6">
-                  <p className="text-base text-gray-700 dark:text-gray-700 leading-relaxed line-clamp-4 h-24 overflow-hidden">
+                <div className="flex-grow flex flex-col justify-center mb-6 bg-white">
+                  <p className="text-base text-gray-700 dark:text-gray-700 leading-relaxed line-clamp-4 h-24 overflow-hidden bg-white">
                     {summary}
                   </p>
                 </div>
 
-                <div className="flex items-center justify-between mt-auto pt-4 border-t border-gray-200 dark:border-gray-300">
+                <div className="flex items-center justify-between mt-auto pt-4 border-t border-gray-200 dark:border-gray-300 bg-white">
                   {post.category && post.category.length > 0 && (
                     <div className="flex flex-wrap gap-1">
                       {post.category.slice(0, 2).map((cat, index) => (
@@ -169,7 +169,7 @@ export function BlogCard({ post }: BlogCardProps) {
                       ))}
                     </div>
                   )}
-                  <div className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-600 font-medium">
+                  <div className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-600 font-medium bg-white">
                     <Eye className="w-4 h-4" />
                     <span>続きを読む</span>
                   </div>

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -126,10 +126,11 @@ export function BlogCard({ post }: BlogCardProps) {
             className="block absolute inset-0 backface-hidden rotate-y-180"
           >
             <Card
-              className="h-full bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-blue-50 dark:to-indigo-100 cursor-pointer !bg-white dark:!bg-white relative z-10 flex flex-col"
+              className="h-full cursor-pointer !bg-white dark:!bg-white relative z-10 flex flex-col"
               data-card="blog-card"
               style={{
                 backgroundColor: "white !important",
+                backgroundImage: "none !important",
                 border: "none !important",
                 color: "rgb(3 7 18) !important",
               }}

--- a/src/components/blog/blog-search.tsx
+++ b/src/components/blog/blog-search.tsx
@@ -137,9 +137,9 @@ export function BlogSearch({
               variant="ghost"
               size="sm"
               onClick={() => handleSearchChange("")}
-              className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 w-6 p-0"
+              className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 w-6 p-0 bg-white dark:bg-white hover:bg-gray-50 dark:hover:bg-gray-50"
             >
-              <X className="h-3 w-3" />
+              <X className="h-3 w-3 text-gray-600 dark:text-gray-600" />
             </Button>
           )}
         </div>
@@ -166,7 +166,12 @@ export function BlogSearch({
 
           {/* フィルタクリアボタン */}
           {hasActiveFilters && (
-            <Button variant="outline" size="sm" onClick={clearSearch}>
+            <Button 
+              variant="outline" 
+              size="sm" 
+              onClick={clearSearch}
+              className="bg-white dark:bg-white hover:bg-gray-50 dark:hover:bg-gray-50 text-gray-600 dark:text-gray-600"
+            >
               <X className="h-4 w-4 mr-1" />
               クリア
             </Button>

--- a/src/components/blog/recruitment-content.tsx
+++ b/src/components/blog/recruitment-content.tsx
@@ -54,10 +54,10 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
       <div className="container mx-auto px-3 sm:px-4 py-6 sm:py-8 max-w-4xl">
         {/* ヘッダー */}
         <div className="text-center mb-12">
-          <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-4">
+          <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
             {groupInfo.groupName}
           </h2>
-          <h3 className="text-xl md:text-2xl text-gray-700 dark:text-gray-300 mb-6">
+          <h3 className="text-xl md:text-2xl text-gray-700 mb-6">
             一緒に音楽を奏でる仲間を募集しています
           </h3>
         </div>
@@ -73,7 +73,7 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
             </CardHeader>
             <CardContent>
               <div 
-                className="prose prose-lg max-w-none text-gray-700 dark:text-gray-300"
+                className="prose prose-lg max-w-none text-gray-700"
                 dangerouslySetInnerHTML={{ __html: groupInfo.description }}
               />
             </CardContent>
@@ -119,14 +119,14 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
                           />
                           {/* Overlay for better UX */}
                           <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300 flex items-center justify-center">
-                            <div className="bg-white/80 dark:bg-gray-800/80 rounded-full px-3 py-1 text-xs font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                            <div className="bg-white/80 rounded-full px-3 py-1 text-xs font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                               クリックで拡大
                             </div>
                           </div>
                         </button>
                       </div>
                     )}
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    <h3 className="text-lg font-semibold text-gray-900">
                       {instrument.instrumentName}
                     </h3>
                   </div>
@@ -148,18 +148,18 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
                 <div className="grid gap-8 md:grid-cols-2">
                   {/* 見学 */}
                   <div className="text-center">
-                    <div className="mx-auto w-20 h-20 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center mb-4">
-                      <Eye className="w-10 h-10 text-blue-600 dark:text-blue-400" />
+                    <div className="mx-auto w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mb-4">
+                      <Eye className="w-10 h-10 text-blue-600" />
                     </div>
-                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+                    <h3 className="text-xl font-semibold text-gray-900 mb-3">
                       見学
                     </h3>
-                    <p className="text-gray-600 dark:text-gray-400 mb-4">
+                    <p className="text-gray-600 mb-4">
                       練習の様子を自由に見学いただけます。<br />
                       いつでも大歓迎です！
                     </p>
-                    <div className="bg-blue-50 dark:bg-blue-900/30 rounded-lg p-3">
-                      <p className="text-sm text-blue-700 dark:text-blue-300 font-medium">
+                    <div className="bg-blue-50 rounded-lg p-3">
+                      <p className="text-sm text-blue-700 font-medium">
                         完全無料・事前連絡不要
                       </p>
                     </div>
@@ -167,18 +167,18 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
 
                   {/* 体験参加 */}
                   <div className="text-center">
-                    <div className="mx-auto w-20 h-20 bg-green-100 dark:bg-green-900 rounded-full flex items-center justify-center mb-4">
-                      <Users className="w-10 h-10 text-green-600 dark:text-green-400" />
+                    <div className="mx-auto w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-4">
+                      <Users className="w-10 h-10 text-green-600" />
                     </div>
-                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+                    <h3 className="text-xl font-semibold text-gray-900 mb-3">
                       体験参加
                     </h3>
-                    <p className="text-gray-600 dark:text-gray-400 mb-4">
+                    <p className="text-gray-600 mb-4">
                       実際に楽器を触って一緒に演奏してみましょう。<br />
                       こちらもいつでも大歓迎です！
                     </p>
-                    <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-3">
-                      <p className="text-sm text-green-700 dark:text-green-300 font-medium">
+                    <div className="bg-green-50 rounded-lg p-3">
+                      <p className="text-sm text-green-700 font-medium">
                         手ぶらでOK・楽器レンタル無料
                       </p>
                     </div>
@@ -186,32 +186,32 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
                 </div>
 
                 {/* 料金体系 */}
-                <div className="bg-gradient-to-r from-orange-50 to-yellow-50 dark:from-orange-900/20 dark:to-yellow-900/20 rounded-lg p-6 border border-orange-200 dark:border-orange-800">
-                  <h4 className="font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+                <div className="bg-gradient-to-r from-orange-50 to-yellow-50 rounded-lg p-6 border border-orange-200">
+                  <h4 className="font-semibold text-gray-900 mb-4 flex items-center gap-2">
                     <Coins className="w-5 h-5 text-orange-500" />
                     料金について
                   </h4>
                   <div className="grid gap-4 md:grid-cols-2">
-                    <div className="bg-white dark:bg-gray-800 rounded-lg p-4">
-                      <h5 className="font-medium text-gray-900 dark:text-white mb-2">初回体験</h5>
-                      <p className="text-2xl font-bold text-green-600 dark:text-green-400 mb-1">無料</p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">楽器レンタル込み</p>
+                    <div className="bg-white rounded-lg p-4">
+                      <h5 className="font-medium text-gray-900 mb-2">初回体験</h5>
+                      <p className="text-2xl font-bold text-green-600 mb-1">無料</p>
+                      <p className="text-sm text-gray-600">楽器レンタル込み</p>
                     </div>
-                    <div className="bg-white dark:bg-gray-800 rounded-lg p-4">
-                      <h5 className="font-medium text-gray-900 dark:text-white mb-2">2回目以降</h5>
-                      <p className="text-2xl font-bold text-orange-600 dark:text-orange-400 mb-1">¥1,000</p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">1回あたり・楽器レンタル込み</p>
+                    <div className="bg-white rounded-lg p-4">
+                      <h5 className="font-medium text-gray-900 mb-2">2回目以降</h5>
+                      <p className="text-2xl font-bold text-orange-600 mb-1">¥1,000</p>
+                      <p className="text-sm text-gray-600">1回あたり・楽器レンタル込み</p>
                     </div>
                   </div>
                 </div>
 
                 {/* 補足情報 */}
-                <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-6">
-                  <h4 className="font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                <div className="bg-gray-50 rounded-lg p-6">
+                  <h4 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
                     <CheckCircle className="w-5 h-5 text-green-500" />
                     ご参加にあたって
                   </h4>
-                  <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
+                  <ul className="space-y-2 text-sm text-gray-600">
                     <li className="flex items-start gap-2">
                       <span className="w-1.5 h-1.5 bg-blue-500 rounded-full mt-2 flex-shrink-0"></span>
                       楽器の経験がなくても大丈夫です
@@ -240,7 +240,7 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
           </div>
 
           {/* 従来のメール連絡先 */}
-          <Card id="contact-email" className="border border-gray-200 dark:border-gray-700">
+          <Card id="contact-email" className="border border-gray-200">
             <CardHeader>
               <CardTitle className="text-lg flex items-center gap-2">
                 <Mail className="w-5 h-5" />
@@ -249,15 +249,15 @@ export function RecruitmentContent({ groupInfo }: RecruitmentContentProps) {
             </CardHeader>
             <CardContent>
               <div className="space-y-4">
-                <p className="text-gray-600 dark:text-gray-400 text-sm">
+                <p className="text-gray-600 text-sm">
                   フォームでの応募が難しい場合は、メールでもお気軽にご連絡ください。
                 </p>
                 
-                <div className="flex items-center gap-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                  <Mail className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                <div className="flex items-center gap-2 p-3 bg-gray-50 rounded-lg">
+                  <Mail className="w-4 h-4 text-gray-600" />
                   <a
                     href={`mailto:${groupInfo.applicationEmail}`}
-                    className="text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-300 transition-colors"
+                    className="text-sm font-medium text-gray-600 hover:text-gray-800 transition-colors"
                   >
                     {groupInfo.applicationEmail}
                   </a>

--- a/src/components/ui/category-badge.tsx
+++ b/src/components/ui/category-badge.tsx
@@ -1,15 +1,15 @@
 import { Badge } from "@/components/ui/badge";
 
-// カテゴリーごとの色設定（microCMSで実際に使用している3つのみ）
+// カテゴリーごとの色設定（ダークモードでもライトモードと同じ色）
 const categoryColors: Record<string, string> = {
-	技術: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
-	日常: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
-	音楽: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+	技術: "bg-blue-100 text-blue-800 dark:bg-blue-100 dark:text-blue-800",
+	日常: "bg-green-100 text-green-800 dark:bg-green-100 dark:text-green-800",
+	音楽: "bg-red-100 text-red-800 dark:bg-red-100 dark:text-red-800",
 };
 
 // デフォルトカラー
 const defaultColor =
-	"bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300";
+	"bg-gray-100 text-gray-800 dark:bg-gray-100 dark:text-gray-800";
 
 interface CategoryBadgeProps {
 	category: string;

--- a/src/components/ui/category-badge.tsx
+++ b/src/components/ui/category-badge.tsx
@@ -1,15 +1,15 @@
 import { Badge } from "@/components/ui/badge";
 
-// カテゴリーごとの色設定（ダークモードでもライトモードと同じ色）
+// カテゴリーごとの色設定（microCMSで実際に使用している3つのみ）
 const categoryColors: Record<string, string> = {
-	技術: "bg-blue-100 text-blue-800 dark:bg-blue-100 dark:text-blue-800",
-	日常: "bg-green-100 text-green-800 dark:bg-green-100 dark:text-green-800",
-	音楽: "bg-red-100 text-red-800 dark:bg-red-100 dark:text-red-800",
+	技術: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
+	日常: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+	音楽: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
 };
 
 // デフォルトカラー
 const defaultColor =
-	"bg-gray-100 text-gray-800 dark:bg-gray-100 dark:text-gray-800";
+	"bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300";
 
 interface CategoryBadgeProps {
 	category: string;


### PR DESCRIPTION
## Summary
  - 募集要項ページのダークモード表示を改善し、一貫性のあるUIを実現
  - 目次以外の要素をライトモードスタイルに統一して可読性を向上
  - 背景は引き続きダークテーマに対応

  ## 変更内容
  - ヘッダータイトルとサブタイトルのテキスト色をライトモード統一
  - 活動内容の説明文テキスト色を統一
  - 楽器名とホバー時のツールチップをライトモード統一
  - 見学・体験参加セクションのアイコン背景とテキスト色を統一
  - 料金体系カードの背景色とテキスト色を統一
  - 補足情報セクションの背景とテキスト色を統一
  - 問い合わせフォームとメール連絡先のボーダー・背景を統一
  - 目次コンポーネントはナビゲーション要素としてダークモード対応維持

  ## Test plan
  - [x] ライトモードで募集要項ページの表示確認
  - [x] ダークモードで募集要項ページの表示確認
  - [x] 目次の動作とスタイリング確認
  - [x] レスポンシブ表示の確認