### PR TITLE
feat: 星のパーティクルとエフェクトシステムを強化

### DIFF
--- a/public/shaders/star-fragment.glsl
+++ b/public/shaders/star-fragment.glsl
@@ -35,7 +35,35 @@ void main() {
         spike = 1.5 + 0.5 * sin(uTime * 10.0 + timeOffset);
     }
     
+    // 白い光と青白い光を混在させる
+    float colorVariation = fract(seed * 0.5); // 0-1の値で色のバリエーション
+    
+    // 星の中心からの距離を計算（0.0が中心、0.5が端）
+    vec2 center = vec2(0.5, 0.5);
+    float distanceFromCenter = distance(gl_PointCoord, center);
+    
+    // #2490BA色をRGBに変換（36, 144, 186）
+    vec3 blueEdgeColor = vec3(36.0/255.0, 144.0/255.0, 186.0/255.0); // #2490BA（外側）
+    vec3 blueCenterColor = vec3(0.3, 0.7, 1.0);                      // #2490BAの明るい青版（中心）
+    vec3 warmWhiteColor = vec3(1.0, 0.9, 0.7);                       // 電球色（暖かい白）
+    vec3 lightBlueGlow = vec3(0.7, 0.9, 1.0);                        // 薄い青白
+    
+    // 3段階の色分布：30%電球色、40%薄い青白、30%グラデーション青
+    vec3 starColor;
+    if (colorVariation < 0.3) {
+        starColor = warmWhiteColor;
+    } else if (colorVariation < 0.7) {
+        starColor = lightBlueGlow;
+    } else {
+        // 中心から端にかけてのグラデーション（明るい青→#2490BA）
+        float gradientFactor = smoothstep(0.0, 0.4, distanceFromCenter);
+        starColor = mix(blueCenterColor, blueEdgeColor, gradientFactor);
+    }
+    
+    float glowIntensity = 1.2 + 0.3 * twinkle; // チカチカに連動したグロー強度
+    
     // 最終色の計算
-    vec3 finalColor = vColor * mouseEffect * twinkle * spike;
+    vec3 baseColor = vColor * mouseEffect * twinkle * spike;
+    vec3 finalColor = baseColor * starColor * glowIntensity;
     gl_FragColor = vec4(finalColor, texColor.a);
 }

--- a/src/components/three/ShootingStar.tsx
+++ b/src/components/three/ShootingStar.tsx
@@ -1,0 +1,110 @@
+// src/components/three/ShootingStar.tsx
+"use client";
+
+import { useRef, useMemo, useLayoutEffect } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+interface ShootingStarProps {
+  onComplete?: () => void;
+  duration?: number; // ms（ゆっくりにしたいなら 3500〜5000 推奨）
+}
+
+export function ShootingStar({
+  onComplete,
+  duration = 4000,
+}: ShootingStarProps) {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const startTime = useRef<number>(0);
+  const initialized = useRef(false);
+  const done = useRef(false);
+
+  // 左上→右下（画面外スタート）
+  const traj = useMemo(() => {
+    const startX = -Math.random() * 30 + -50; // さらに左外
+    const startY = Math.random() * 30 + 40; // 上外
+    const d = Math.random() * 40 + 60;
+    const endX = startX + d;
+    const endY = startY - d;
+    const z = -Math.random() * 15 - 20;
+    const angle = Math.atan2(endY - startY, endX - startX) - Math.PI / 2;
+    return { startX, startY, endX, endY, z, angle };
+  }, []);
+
+  // 形状/材質は1回だけ
+  const geometry = useMemo(
+    () => new THREE.CylinderGeometry(0.005, 0.015, 3.5, 6),
+    []
+  );
+  const material = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: 0xaabbdd,
+        transparent: true,
+        opacity: 0,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        depthTest: false,
+        toneMapped: false,
+      }),
+    []
+  );
+
+  // 初回から開始位置に配置（中心フラッシュ防止）
+  useLayoutEffect(() => {
+    const m = meshRef.current;
+    if (!m) return;
+    m.visible = false;
+    m.position.set(traj.startX, traj.startY, traj.z);
+    m.rotation.z = traj.angle;
+    m.renderOrder = 10;
+    return () => {
+      geometry.dispose();
+      material.dispose();
+    };
+  }, [traj, geometry, material]);
+
+  // 補間関数
+  const smoothstep = (e0: number, e1: number, x: number) => {
+    const t = THREE.MathUtils.clamp((x - e0) / (e1 - e0), 0, 1);
+    return t * t * (3 - 2 * t);
+  };
+
+  useFrame((state) => {
+    const m = meshRef.current;
+    if (!m || done.current) return;
+
+    if (!initialized.current) {
+      startTime.current = state.clock.getElapsedTime() * 1000;
+      m.visible = true;
+      initialized.current = true;
+    }
+
+    const t = state.clock.getElapsedTime() * 1000 - startTime.current;
+    const p = THREE.MathUtils.clamp(t / duration, 0, 1); // 0→1
+
+    if (p >= 1) {
+      done.current = true;
+      m.visible = false;
+      onComplete?.();
+      return;
+    }
+
+    // 位置（線形でOK。もっと“しっとり”なら easeInOut してもOK）
+    m.position.x = THREE.MathUtils.lerp(traj.startX, traj.endX, p);
+    m.position.y = THREE.MathUtils.lerp(traj.startY, traj.endY, p);
+
+    // より儚いフェード：ゆっくり現れて、ゆっくり消えていく
+    const fadeIn = smoothstep(0.0, 0.25, p);
+    const fadeOut = 1 - smoothstep(0.4, 1.0, p);
+    const maxOpacity = 0.6; // 最大不透明度を下げて儚く
+    material.opacity = THREE.MathUtils.clamp(fadeIn * fadeOut * maxOpacity, 0, 1);
+
+    // より繊細な尾の効果
+    const tail = smoothstep(0.6, 1.0, p); // 0→1
+    m.scale.y = 1 - 0.85 * tail; // 1→0.15 まで縮む（より緩やか）
+    m.scale.x = 1 - 0.4 * tail; // 横方向も少し縮める
+  });
+
+  return <mesh ref={meshRef} geometry={geometry} material={material} />;
+}

--- a/src/components/three/ShootingStars.tsx
+++ b/src/components/three/ShootingStars.tsx
@@ -1,0 +1,51 @@
+// src/components/three/ShootingStars.tsx
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { ShootingStar } from "./ShootingStar";
+
+interface ShootingStarsProps {
+  interval?: number; // 次の星を出すまでの待ち時間(ms)
+  duration?: number; // 星が流れる時間(ms)
+}
+
+export function ShootingStars({
+  interval = 3500,
+  duration = 4000,
+}: ShootingStarsProps) {
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const scheduleNext = useCallback(() => {
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      setActiveId(Date.now()); // 1つだけ生成
+    }, interval);
+  }, [interval]);
+
+  useEffect(() => {
+    // 初回はすぐ1つ出す
+    setActiveId(Date.now());
+    return () => clearTimer();
+  }, []);
+
+  const handleComplete = useCallback(() => {
+    setActiveId(null);
+    scheduleNext(); // 完了後に次を予約（常に1つだけ）
+  }, [scheduleNext]);
+
+  return activeId !== null ? (
+    <ShootingStar
+      key={activeId}
+      duration={duration}
+      onComplete={handleComplete}
+    />
+  ) : null;
+}

--- a/src/components/three/StarParticles.tsx
+++ b/src/components/three/StarParticles.tsx
@@ -63,7 +63,8 @@ export function StarParticles({
       positions[i * 3] = (Math.random() - 0.5) * 50;
       positions[i * 3 + 1] = (Math.random() - 0.5) * 50;
       positions[i * 3 + 2] = (Math.random() - 0.5) * 50;
-      color.setRGB(1, 1, 1);
+      // 青白い色に設定（少し青みがかった白）
+      color.setRGB(0.8, 0.9, 1.0);
       colors[i * 3] = color.r;
       colors[i * 3 + 1] = color.g;
       colors[i * 3 + 2] = color.b;

--- a/src/components/three/hero-canvas.tsx
+++ b/src/components/three/hero-canvas.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import * as THREE from "three";
 import { StarParticles } from "./StarParticles";
+import { ShootingStars } from "./ShootingStars";
 import VideoCardsRenderer from "./VideoCardsRenderer";
 import NextSection from "./NextSection";
 import { FeatherCircleMaterial } from "./materials";
@@ -484,6 +485,7 @@ function HeroScene({ scrollProgress, videoSlides, onCardClick }: HeroSceneProps)
         <group ref={starGroupRef}>
           <Suspense fallback={null}>
             <StarParticles selfRotate={false} position={[0, 0, -10]} />
+            <ShootingStars interval={3500} duration={4000} />
           </Suspense>
         </group>
 


### PR DESCRIPTION
- 星のパーティクルを青白い色調に変更（RGB: 0.8, 0.9, 1.0）
- フラグメントシェーダーで3段階の色分布を実装
  - 30%電球色（暖かい白）
  - 40%薄い青白
  - 30%グラデーション青（#2490BA）
- 流れ星機能を実装（ShootingStar + ShootingStars）
- 左上から右下への対角線軌道
- 儚く繊細なフェードイン・アウト効果
- 3.5秒間隔での自動生成

