### PR TITLE
fix: 動画カード表示問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev",
+		"dev": "next dev -p 3000",
 		"build": "next build",
 		"start": "next start",
 		"lint": "biome lint .",

--- a/src/components/three/VideoCard3D.tsx
+++ b/src/components/three/VideoCard3D.tsx
@@ -102,8 +102,26 @@ export default function VideoCard3D({
 			v.loop = false;
 			v.muted = true;
 			v.playsInline = true;
-			v.preload = "metadata";
+			v.preload = "auto"; // metadataからautoに変更して確実に読み込む
 			videoRef.current = v;
+
+			// 動画が十分に読み込まれたらtextureLoadedをtrueに
+			v.oncanplay = () => {
+				console.log(`✅ [${title}] 動画再生可能:`, videoSrc);
+				setTextureLoaded(true);
+			};
+
+			v.onloadedmetadata = () => {
+				console.log(`📊 [${title}] メタデータ読み込み完了`);
+			};
+
+			v.onerror = (e) => {
+				console.error(`❌ [${title}] 動画読み込みエラー:`, videoSrc);
+				console.error('Error details:', e);
+				console.error('Video element:', v);
+				console.error('NetworkState:', v.networkState);
+				console.error('ReadyState:', v.readyState);
+			};
 
 			const tex = new VideoTexture(v);
 			tex.minFilter = THREE.LinearFilter;
@@ -112,7 +130,6 @@ export default function VideoCard3D({
 			tex.flipY = false; // DoubleSide使用時は反転させない
 			(tex as any).colorSpace = THREE.SRGBColorSpace;
 			videoTexture.current = tex;
-			setTextureLoaded(true);
 		} else if (mediaType === "image" && imageSrc) {
 			new TextureLoader().load(
 				imageSrc,


### PR DESCRIPTION
## 概要
動画カードが表示されない問題を修正しました。

## 変更内容
- 開発サーバーのポートを3000に変更（CORS設定との整合性のため）
- VideoCard3Dで動画読み込み完了を待ってからtextureLoadedをtrueに設定
- 動画のpreloadをautoに変更して確実に読み込む
- エラーハンドリングとデバッグログを追加

## 原因
サーバー側の`.htaccess`が`http://localhost:3000`を許可していたが、開発環境がポート3001で動作していたため、CORSエラーが発生していました。

## テスト
- ローカル環境で動画カードが正しく3つ表示されることを確認