### PR TITLE
Feature/card hover pointer

### DIFF
--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -7,182 +7,191 @@ import { HeroActionButton } from "@/components/ui/hero-action-button";
 import MissionSection from "./MissionSection";
 
 export default function HomeClient() {
-  const [scrollProgress, setScrollProgress] = useState(0);
-  const [isCircleFullyExpanded, setIsCircleFullyExpanded] = useState(false);
+	const [scrollProgress, setScrollProgress] = useState(0);
+	const [isCircleFullyExpanded, setIsCircleFullyExpanded] = useState(false);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.scrollY;
-      const docHeight =
-        document.documentElement.scrollHeight - window.innerHeight;
-      const scrolled = scrollTop / docHeight;
-      setScrollProgress(scrolled); // 1以上も許可（MISSIONセクションで100%超のスクロールを使用）
-    };
+	useEffect(() => {
+		const handleScroll = () => {
+			const scrollTop = window.scrollY;
+			const docHeight =
+				document.documentElement.scrollHeight - window.innerHeight;
+			const scrolled = scrollTop / docHeight;
+			setScrollProgress(scrolled); // 1以上も許可（MISSIONセクションで100%超のスクロールを使用）
+		};
 
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+		window.addEventListener("scroll", handleScroll);
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
 
-  // 黒い円の開始タイミング（hero-canvas.tsxのCIRCLE_SCROLL_STARTと同期）
-  const CIRCLE_START = 0.86;
-  const CIRCLE_SCROLL_END = 0.95; // hero-canvas.tsxのCIRCLE_SCROLL_END
-  const CIRCLE_ACTUAL_END = 0.98; // 慣性を考慮した実際の完全拡大タイミング（CIRCLE_SMOOTH_EXPAND = 0.25を考慮）
+	// 黒い円の開始タイミング（hero-canvas.tsxのCIRCLE_SCROLL_STARTと同期）
+	const CIRCLE_START = 0.86;
+	const CIRCLE_SCROLL_END = 0.95; // hero-canvas.tsxのCIRCLE_SCROLL_END
+	const CIRCLE_ACTUAL_END = 0.98; // 慣性を考慮した実際の完全拡大タイミング（CIRCLE_SMOOTH_EXPAND = 0.25を考慮）
 
-  // 黒い円が完全に拡大したらフラグを立てる（戻る時はfalseに戻す）
-  useEffect(() => {
-    if (scrollProgress >= CIRCLE_ACTUAL_END) {
-      if (!isCircleFullyExpanded) {
-        setIsCircleFullyExpanded(true);
-        console.log('Circle fully expanded at scrollProgress:', scrollProgress);
-      }
-    } else {
-      // スクロールを戻して黒い円が縮小したらフラグをfalseに戻す
-      if (isCircleFullyExpanded) {
-        setIsCircleFullyExpanded(false);
-        console.log('Circle shrinking at scrollProgress:', scrollProgress);
-      }
-    }
-  }, [scrollProgress, CIRCLE_ACTUAL_END, isCircleFullyExpanded]);
+	// 黒い円が完全に拡大したらフラグを立てる（戻る時はfalseに戻す）
+	useEffect(() => {
+		if (scrollProgress >= CIRCLE_ACTUAL_END) {
+			if (!isCircleFullyExpanded) {
+				setIsCircleFullyExpanded(true);
+				console.log("Circle fully expanded at scrollProgress:", scrollProgress);
+			}
+		} else {
+			// スクロールを戻して黒い円が縮小したらフラグをfalseに戻す
+			if (isCircleFullyExpanded) {
+				setIsCircleFullyExpanded(false);
+				console.log("Circle shrinking at scrollProgress:", scrollProgress);
+			}
+		}
+	}, [scrollProgress, CIRCLE_ACTUAL_END, isCircleFullyExpanded]);
 
-  // 黒い円が拡大中はすべてのUI要素を非表示
-  const isCircleExpanded = scrollProgress >= CIRCLE_SCROLL_END;
+	// 黒い円が拡大中はすべてのUI要素を非表示
+	const isCircleExpanded = scrollProgress >= CIRCLE_SCROLL_END;
 
-  // 第1テキストの表示タイミング（0-30%でフェードイン、30-45%で表示、45-55%でフェードアウト）
-  const text1FadeIn = Math.max(0, Math.min(1, scrollProgress * 3.333)); // 0-30%
-  const text1FadeOut = Math.max(0, Math.min(1, (0.55 - scrollProgress) * 10)); // 45-55%
-  const text1Opacity = Math.min(text1FadeIn, text1FadeOut);
+	// 第1テキストの表示タイミング（0-30%でフェードイン、30-45%で表示、45-55%でフェードアウト）
+	const text1FadeIn = Math.max(0, Math.min(1, scrollProgress * 3.333)); // 0-30%
+	const text1FadeOut = Math.max(0, Math.min(1, (0.55 - scrollProgress) * 10)); // 45-55%
+	const text1Opacity = Math.min(text1FadeIn, text1FadeOut);
 
-  // 第2テキストの表示タイミング（60-65%でフェードイン、65-75%で表示、75-80%でフェードアウト）
-  const text2FadeIn = Math.max(0, Math.min(1, (scrollProgress - 0.6) * 20)); // 60-65%
-  const text2FadeOut = Math.max(0, Math.min(1, (0.8 - scrollProgress) * 20)); // 75-80%
-  const text2Opacity = Math.min(text2FadeIn, text2FadeOut);
+	// 第2テキストの表示タイミング（60-65%でフェードイン、65-75%で表示、75-80%でフェードアウト）
+	const text2FadeIn = Math.max(0, Math.min(1, (scrollProgress - 0.6) * 20)); // 60-65%
+	const text2FadeOut = Math.max(0, Math.min(1, (0.8 - scrollProgress) * 20)); // 75-80%
+	const text2Opacity = Math.min(text2FadeIn, text2FadeOut);
 
-  // 第3テキストの表示タイミング（80-82%でフェードイン、82-85%で表示、黒い円開始で消える）
-  const text3FadeIn = Math.max(0, Math.min(1, (scrollProgress - 0.8) * 50)); // 80-82%
-  const text3FadeOut = Math.max(
-    0,
-    Math.min(1, (CIRCLE_START - scrollProgress) * 20)
-  ); // 黒い円開始で急速にフェードアウト
-  const text3Opacity = Math.min(text3FadeIn, text3FadeOut);
+	// 第3テキストの表示タイミング（80-82%でフェードイン、82-85%で表示、黒い円開始で消える）
+	const text3FadeIn = Math.max(0, Math.min(1, (scrollProgress - 0.8) * 50)); // 80-82%
+	const text3FadeOut = Math.max(
+		0,
+		Math.min(1, (CIRCLE_START - scrollProgress) * 20),
+	); // 黒い円開始で急速にフェードアウト
+	const text3Opacity = Math.min(text3FadeIn, text3FadeOut);
 
-  return (
-    <>
-      {/* 屋号を左上に固定配置 */}
-      <div className="fixed top-8 left-8 z-10 pointer-events-none">
-        <h1 className="text-2xl md:text-3xl font-bold text-white">
-          TANEBI CREATIVE
-        </h1>
-      </div>
+	return (
+		<>
+			{/* 屋号を左上に固定配置 */}
+			<div className="fixed top-8 left-8 z-10 pointer-events-none">
+				<h1 className="text-2xl md:text-3xl font-bold text-white">
+					TANEBI CREATIVE
+				</h1>
+			</div>
 
-      {/* 第1テキスト: 最初のキャッチコピー */}
-      {!isCircleExpanded && (
-        <div
-          className="fixed left-8 md:left-16 top-1/2 -translate-y-1/2 z-10 transition-all duration-1000 ease-out max-w-4xl pointer-events-none"
-          style={{
-            opacity: text1Opacity,
-            transform: `translateY(-50%) translateX(${
-              (1 - text1Opacity) * -20
-            }px)`,
-          }}
-        >
-        <h2 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-8">
-          デジタルの
-          <br />
-          <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-            困りごとに
-          </span>
-          <br />
-          寄り添いサポート
-        </h2>
-        <p className="text-lg md:text-2xl text-white/70 leading-relaxed">
-          Web / App / AI
-          <br />
-          <span className="text-white/90">次の時代の表現を、ともに創る</span>
-        </p>
-        </div>
-      )}
+			{/* 第1テキスト: 最初のキャッチコピー */}
+			{!isCircleExpanded && (
+				<div
+					className="fixed left-8 md:left-16 top-1/2 -translate-y-1/2 z-10 transition-all duration-1000 ease-out max-w-4xl pointer-events-none"
+					style={{
+						opacity: text1Opacity,
+						transform: `translateY(-50%) translateX(${
+							(1 - text1Opacity) * -20
+						}px)`,
+					}}
+				>
+					<h2 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-8">
+						デジタルの
+						<br />
+						<span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+							困りごとに
+						</span>
+						<br />
+						寄り添いサポート
+					</h2>
+					<p className="text-lg md:text-2xl text-white/70 leading-relaxed">
+						Web / App / AI
+						<br />
+						<span className="text-white/90">次の時代の表現を、ともに創る</span>
+					</p>
+				</div>
+			)}
 
-      {/* 第2テキスト: 詳細メッセージ */}
-      {!isCircleExpanded && (
-        <div
-          className="fixed left-8 md:left-16 top-1/2 -translate-y-1/2 z-10 transition-all duration-1000 ease-out max-w-4xl pointer-events-none"
-          style={{
-            opacity: text2Opacity,
-            transform: `translateY(-50%) translateX(${
-              (1 - text2Opacity) * -20
-            }px)`,
-          }}
-        >
-        <h2 className="text-3xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-8">
-          現場が抱える
-          <br />
-          デジタルの悩みを、
-          <br />
-          もっと
-          <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-            シンプル
-          </span>
-          に。
-        </h2>
-        <p className="text-base md:text-xl text-white/80 leading-relaxed space-y-2">
-          <span className="block">わかりやすく、運用まで一緒に支えるWeb。</span>
-          <span className="block">
-            使いやすく、日々の業務を軽くするアプリ。
-          </span>
-          <span className="block">身近に活かせるAI。</span>
-          <span className="block mt-4 text-white/90 font-medium">
-            そのすべてを、伴走しながら実現します。
-          </span>
-        </p>
-        </div>
-      )}
+			{/* 第2テキスト: 詳細メッセージ */}
+			{!isCircleExpanded && (
+				<div
+					className="fixed left-8 md:left-16 top-1/2 -translate-y-1/2 z-10 transition-all duration-1000 ease-out max-w-4xl pointer-events-none"
+					style={{
+						opacity: text2Opacity,
+						transform: `translateY(-50%) translateX(${
+							(1 - text2Opacity) * -20
+						}px)`,
+					}}
+				>
+					<h2 className="text-3xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-8">
+						現場が抱える
+						<br />
+						デジタルの悩みを、
+						<br />
+						もっと
+						<span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+							シンプル
+						</span>
+						に。
+					</h2>
+					<p className="text-base md:text-xl text-white/80 leading-relaxed space-y-2">
+						<span className="block">
+							わかりやすく、運用まで一緒に支えるWeb。
+						</span>
+						<span className="block">
+							使いやすく、日々の業務を軽くするアプリ。
+						</span>
+						<span className="block">身近に活かせるAI。</span>
+						<span className="block mt-4 text-white/90 font-medium">
+							そのすべてを、伴走しながら実現します。
+						</span>
+					</p>
+				</div>
+			)}
 
-      {/* 第3テキスト: CTAメッセージ */}
-      {!isCircleExpanded && (
-        <div
-          className="fixed left-8 md:left-16 top-1/2 -translate-y-1/2 z-10 transition-all duration-1000 ease-out max-w-3xl pointer-events-none"
-          style={{
-            opacity: text3Opacity,
-            transform: `translateY(-50%) translateX(${
-              (1 - text3Opacity) * -20
-            }px)`,
-          }}
-        >
-        <h2 className="text-3xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
-          あなたの
-          <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-            "困った"
-          </span>
-          を、
-          <br />
-          今すぐ一緒にほどきませんか？
-        </h2>
-        <p className="text-xl md:text-2xl text-white/90 font-medium">
-          まずはご相談ください。
-        </p>
-        </div>
-      )}
+			{/* 第3テキスト: CTAメッセージ */}
+			{!isCircleExpanded && (
+				<div
+					className="fixed left-8 md:left-16 top-1/2 -translate-y-1/2 z-10 transition-all duration-1000 ease-out max-w-3xl pointer-events-none"
+					style={{
+						opacity: text3Opacity,
+						transform: `translateY(-50%) translateX(${
+							(1 - text3Opacity) * -20
+						}px)`,
+					}}
+				>
+					<h2 className="text-3xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
+						あなたの
+						<span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+							"困った"
+						</span>
+						を、
+						<br />
+						今すぐ一緒にほどきませんか？
+					</h2>
+					<p className="text-xl md:text-2xl text-white/90 font-medium">
+						まずはご相談ください。
+					</p>
+				</div>
+			)}
 
-      {/* アクションボタン群 */}
-      {!isCircleExpanded && (
-        <HeroActions scrollProgress={scrollProgress} position="right">
-          <HeroActionButton href="/blog" label="ブログを見る" variant="primary" />
-          <HeroActionButton href="/about" label="About" variant="secondary" />
-          <HeroActionButton
-            href="/contact"
-            label="お問い合わせ"
-            variant="secondary"
-          />
-        </HeroActions>
-      )}
+			{/* アクションボタン群 */}
+			{!isCircleExpanded && (
+				<HeroActions scrollProgress={scrollProgress} position="right">
+					<HeroActionButton
+						href="/blog"
+						label="ブログを見る"
+						variant="primary"
+					/>
+					<HeroActionButton href="/about" label="About" variant="secondary" />
+					<HeroActionButton
+						href="/contact"
+						label="お問い合わせ"
+						variant="secondary"
+					/>
+				</HeroActions>
+			)}
 
-      {/* MISSIONセクション */}
-      <MissionSection scrollProgress={scrollProgress} isCircleFullyExpanded={isCircleFullyExpanded} />
+			{/* MISSIONセクション */}
+			<MissionSection
+				scrollProgress={scrollProgress}
+				isCircleFullyExpanded={isCircleFullyExpanded}
+			/>
 
-      {/* スクロール可能なコンテンツエリア（透明） */}
-      <div className="w-full pointer-events-none" style={{ height: "1000vh" }}>
-        {/* 空のコンテンツでスクロールを可能にする */}
-      </div>
-    </>
-  );
+			{/* スクロール可能なコンテンツエリア（透明） */}
+			<div className="w-full pointer-events-none" style={{ height: "1000vh" }}>
+				{/* 空のコンテンツでスクロールを可能にする */}
+			</div>
+		</>
+	);
 }

--- a/src/app/components/MissionSection.tsx
+++ b/src/app/components/MissionSection.tsx
@@ -4,8 +4,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 interface MissionSectionProps {
-  scrollProgress: number; // 0〜1 の全体スクロール進捗（親から供給）
-  isCircleFullyExpanded: boolean; // 円が拡大完了したトリガ
+	scrollProgress: number; // 0〜1 の全体スクロール進捗（親から供給）
+	isCircleFullyExpanded: boolean; // 円が拡大完了したトリガ
 }
 
 // ユーティリティ
@@ -14,167 +14,167 @@ const remap01 = (v: number, a: number, b: number) => clamp((v - a) / (b - a));
 const easeOutCubic = (t: number) => 1 - Math.pow(1 - clamp(t), 3);
 
 export default function MissionSection({
-  scrollProgress,
-  isCircleFullyExpanded,
+	scrollProgress,
+	isCircleFullyExpanded,
 }: MissionSectionProps) {
-  // ======= 調整パラメータ（ここをいじるだけで遅くできます） =======
-  const SECTION_START = 0.94; // この位置から演出を開始
-  const SECTION_END = 0.999; // この位置で演出を完了（区間を広げるほどゆっくり）
-  const PROGRESS_SPEED_FORWARD = 0.25; // 1秒あたり最大で 0.25 しか進まない（もっと遅く→0.15 など）
-  const PROGRESS_SPEED_BACKWARD = 0.6; // 戻る時は速く（0.6 = 約2.4倍速）
-  const SMOOTH_ALPHA = 0.08; // 慣性（追従割合）。小さいほど粘る
-  const GAMMA = 1.8; // >1 で序盤をさらに遅く（2.2 とかでもOK）
+	// ======= 調整パラメータ（ここをいじるだけで遅くできます） =======
+	const SECTION_START = 0.94; // この位置から演出を開始
+	const SECTION_END = 0.999; // この位置で演出を完了（区間を広げるほどゆっくり）
+	const PROGRESS_SPEED_FORWARD = 0.25; // 1秒あたり最大で 0.25 しか進まない（もっと遅く→0.15 など）
+	const PROGRESS_SPEED_BACKWARD = 0.6; // 戻る時は速く（0.6 = 約2.4倍速）
+	const SMOOTH_ALPHA = 0.08; // 慣性（追従割合）。小さいほど粘る
+	const GAMMA = 1.8; // >1 で序盤をさらに遅く（2.2 とかでもOK）
 
-  // 生のターゲット進捗（0→1）
-  const rawTarget = useMemo(() => {
-    if (!isCircleFullyExpanded) return 0;
-    return remap01(scrollProgress, SECTION_START, SECTION_END);
-  }, [scrollProgress, isCircleFullyExpanded]);
+	// 生のターゲット進捗（0→1）
+	const rawTarget = useMemo(() => {
+		if (!isCircleFullyExpanded) return 0;
+		return remap01(scrollProgress, SECTION_START, SECTION_END);
+	}, [scrollProgress, isCircleFullyExpanded]);
 
-  // ガンマで序盤減速（ターゲット進捗に適用）
-  const shapedTarget = Math.pow(rawTarget, GAMMA);
+	// ガンマで序盤減速（ターゲット進捗に適用）
+	const shapedTarget = Math.pow(rawTarget, GAMMA);
 
-  // 速度上限＋慣性つきの追従進捗（実際に描画に使う）
-  const targetRef = useRef(0);
-  const currentRef = useRef(0);
-  const [sectionProgress, setSectionProgress] = useState(0);
+	// 速度上限＋慣性つきの追従進捗（実際に描画に使う）
+	const targetRef = useRef(0);
+	const currentRef = useRef(0);
+	const [sectionProgress, setSectionProgress] = useState(0);
 
-  useEffect(() => {
-    targetRef.current = shapedTarget;
-  }, [shapedTarget]);
+	useEffect(() => {
+		targetRef.current = shapedTarget;
+	}, [shapedTarget]);
 
-  useEffect(() => {
-    let raf = 0;
-    let last = performance.now();
+	useEffect(() => {
+		let raf = 0;
+		let last = performance.now();
 
-    const loop = (now: number) => {
-      const dt = (now - last) / 1000; // 秒
-      last = now;
+		const loop = (now: number) => {
+			const dt = (now - last) / 1000; // 秒
+			last = now;
 
-      const tgt = targetRef.current;
-      let cur = currentRef.current;
+			const tgt = targetRef.current;
+			let cur = currentRef.current;
 
-      // 差分
-      const diff = tgt - cur;
+			// 差分
+			const diff = tgt - cur;
 
-      // 速度上限（進む時と戻る時で切り替え）
-      const isGoingForward = diff > 0;
-      const speedLimit = isGoingForward
-        ? PROGRESS_SPEED_FORWARD
-        : PROGRESS_SPEED_BACKWARD;
-      const maxStep = speedLimit * dt;
+			// 速度上限（進む時と戻る時で切り替え）
+			const isGoingForward = diff > 0;
+			const speedLimit = isGoingForward
+				? PROGRESS_SPEED_FORWARD
+				: PROGRESS_SPEED_BACKWARD;
+			const maxStep = speedLimit * dt;
 
-      // 慣性追従によるステップ
-      const inertialStep = diff * SMOOTH_ALPHA;
+			// 慣性追従によるステップ
+			const inertialStep = diff * SMOOTH_ALPHA;
 
-      // 実際に適用するステップは「慣性」と「速度上限」の小さい方
-      const step =
-        Math.abs(inertialStep) > maxStep
-          ? Math.sign(inertialStep) * maxStep
-          : inertialStep;
+			// 実際に適用するステップは「慣性」と「速度上限」の小さい方
+			const step =
+				Math.abs(inertialStep) > maxStep
+					? Math.sign(inertialStep) * maxStep
+					: inertialStep;
 
-      cur += step;
-      currentRef.current = cur;
-      setSectionProgress(cur);
+			cur += step;
+			currentRef.current = cur;
+			setSectionProgress(cur);
 
-      raf = requestAnimationFrame(loop);
-    };
+			raf = requestAnimationFrame(loop);
+		};
 
-    raf = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(raf);
-  }, []);
+		raf = requestAnimationFrame(loop);
+		return () => cancelAnimationFrame(raf);
+	}, []);
 
-  // 表示フラグ
-  const showSection = isCircleFullyExpanded;
-  const showMission = sectionProgress >= 0.15;
-  const showCreative = sectionProgress >= 0.3;
-  const showDescription = sectionProgress >= 0.97; // アニメーション完了後に詳細テキストを表示
+	// 表示フラグ
+	const showSection = isCircleFullyExpanded;
+	const showMission = sectionProgress >= 0.15;
+	const showCreative = sectionProgress >= 0.3;
+	const showDescription = sectionProgress >= 0.97; // アニメーション完了後に詳細テキストを表示
 
-  // 段階マッピング（ここもゆっくり化）
-  const zAxisProgress = easeOutCubic(remap01(sectionProgress, 0.3, 0.7)); // 手前→0
-  const horizontalProgress = easeOutCubic(remap01(sectionProgress, 0.75, 0.95)); // 左右開き
+	// 段階マッピング（ここもゆっくり化）
+	const zAxisProgress = easeOutCubic(remap01(sectionProgress, 0.3, 0.7)); // 手前→0
+	const horizontalProgress = easeOutCubic(remap01(sectionProgress, 0.75, 0.95)); // 左右開き
 
-  // matrix 用パラメータ
-  const scale = 1 + (1 - zAxisProgress) * 4; // 5→1
-  const leftTx = -100 * horizontalProgress;
-  const rightTx = +100 * horizontalProgress;
-  const upTy = -25 * (1 - horizontalProgress);
-  const dnTy = +25 * (1 - horizontalProgress);
+	// matrix 用パラメータ
+	const scale = 1 + (1 - zAxisProgress) * 4; // 5→1
+	const leftTx = -100 * horizontalProgress;
+	const rightTx = +100 * horizontalProgress;
+	const upTy = -25 * (1 - horizontalProgress);
+	const dnTy = +25 * (1 - horizontalProgress);
 
-  return (
-    <div
-      className={`fixed inset-0 z-20 mission-scrollbar ${
-        showDescription ? "overflow-y-auto" : "overflow-hidden"
-      }`}
-      style={{
-        opacity: showSection ? 1 : 0,
-        pointerEvents: showSection ? "auto" : "none",
-        transition: "opacity 0.5s ease-out",
-      }}
-    >
-      {/* MISSION + CREATIVE THINKING エリア（100vh） */}
-      <div className="h-screen flex flex-col items-center justify-center gap-8 px-8">
-        {/* タイトル */}
-        <h2
-          className="text-6xl md:text-8xl font-bold text-white"
-          style={{
-            opacity: showMission ? 1 : 0,
-            transform: `translateY(${showMission ? 0 : -20}px)`,
-            transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
-          }}
-        >
-          MISSION
-        </h2>
+	return (
+		<div
+			className={`fixed inset-0 z-20 mission-scrollbar ${
+				showDescription ? "overflow-y-auto" : "overflow-hidden"
+			}`}
+			style={{
+				opacity: showSection ? 1 : 0,
+				pointerEvents: showSection ? "auto" : "none",
+				transition: "opacity 0.5s ease-out",
+			}}
+		>
+			{/* MISSION + CREATIVE THINKING エリア（100vh） */}
+			<div className="h-screen flex flex-col items-center justify-center gap-8 px-8">
+				{/* タイトル */}
+				<h2
+					className="text-6xl md:text-8xl font-bold text-white"
+					style={{
+						opacity: showMission ? 1 : 0,
+						transform: `translateY(${showMission ? 0 : -20}px)`,
+						transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
+					}}
+				>
+					MISSION
+				</h2>
 
-        {/* 2語 */}
-        <div
-          className="relative flex items-center justify-center"
-          style={{ perspective: "1000px", minHeight: 150, width: "100%" }}
-        >
-          {/* transform は rAF で毎フレ更新 → transition は opacity のみ */}
-          <p
-            className="text-2xl md:text-4xl text-white/90 font-bold absolute will-change-transform"
-            style={{
-              opacity: showCreative ? 1 : 0,
-              transform: showCreative
-                ? `matrix(${scale}, 0, 0, ${scale}, ${leftTx}, ${upTy})`
-                : `matrix(5, 0, 0, 5, 0, -200)`,
-              transition: "opacity 0.5s ease-out",
-            }}
-          >
-            CREATIVE
-          </p>
+				{/* 2語 */}
+				<div
+					className="relative flex items-center justify-center"
+					style={{ perspective: "1000px", minHeight: 150, width: "100%" }}
+				>
+					{/* transform は rAF で毎フレ更新 → transition は opacity のみ */}
+					<p
+						className="text-2xl md:text-4xl text-white/90 font-bold absolute will-change-transform"
+						style={{
+							opacity: showCreative ? 1 : 0,
+							transform: showCreative
+								? `matrix(${scale}, 0, 0, ${scale}, ${leftTx}, ${upTy})`
+								: `matrix(5, 0, 0, 5, 0, -200)`,
+							transition: "opacity 0.5s ease-out",
+						}}
+					>
+						CREATIVE
+					</p>
 
-          <p
-            className="text-2xl md:text-4xl text-white/90 font-bold absolute will-change-transform"
-            style={{
-              opacity: showCreative ? 1 : 0,
-              transform: showCreative
-                ? `matrix(${scale}, 0, 0, ${scale}, ${rightTx}, ${dnTy})`
-                : `matrix(5, 0, 0, 5, 0, 200)`,
-              transition: "opacity 0.5s ease-out 0.12s",
-            }}
-          >
-            THINKING
-          </p>
-        </div>
-      </div>
+					<p
+						className="text-2xl md:text-4xl text-white/90 font-bold absolute will-change-transform"
+						style={{
+							opacity: showCreative ? 1 : 0,
+							transform: showCreative
+								? `matrix(${scale}, 0, 0, ${scale}, ${rightTx}, ${dnTy})`
+								: `matrix(5, 0, 0, 5, 0, 200)`,
+							transition: "opacity 0.5s ease-out 0.12s",
+						}}
+					>
+						THINKING
+					</p>
+				</div>
+			</div>
 
-      {/* 詳細テキストエリア */}
-      <div
-        className="w-full min-h-screen flex flex-col items-center justify-center px-8 py-20"
-        style={{
-          opacity: showDescription ? 1 : 0,
-          transform: `translateY(${showDescription ? 0 : 30}px)`,
-          transition: "opacity 1s ease-out, transform 1s ease-out",
-        }}
-      >
-        <div className="max-w-3xl text-center">
-          <p className="text-base md:text-lg text-white/80 leading-relaxed">
-            ここにMISSIONの詳細テキストが入ります。ここにMISSIONの詳細テキストが入ります。ここにMISSIONの詳細テキストが入ります。
-          </p>
-        </div>
-      </div>
-    </div>
-  );
+			{/* 詳細テキストエリア */}
+			<div
+				className="w-full min-h-screen flex flex-col items-center justify-center px-8 py-20"
+				style={{
+					opacity: showDescription ? 1 : 0,
+					transform: `translateY(${showDescription ? 0 : 30}px)`,
+					transition: "opacity 1s ease-out, transform 1s ease-out",
+				}}
+			>
+				<div className="max-w-3xl text-center">
+					<p className="text-base md:text-lg text-white/80 leading-relaxed">
+						ここにMISSIONの詳細テキストが入ります。ここにMISSIONの詳細テキストが入ります。ここにMISSIONの詳細テキストが入ります。
+					</p>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CategoryBadge } from "@/components/ui/category-badge";
 import type { BlogPost } from "@/lib/microcms";
 import { Clock, Eye, Calendar } from "lucide-react";
+import { CardHoverPointer } from "@/components/three/card-hover-pointer";
 
 interface BlogCardProps {
 	post: BlogPost;
@@ -31,6 +32,8 @@ function getReadingTime(content: string): number {
 export function BlogCard({ post }: BlogCardProps) {
 	const [isFlipped, setIsFlipped] = useState(false);
 	const [isImageExpanded, setIsImageExpanded] = useState(false);
+	const [isHovering, setIsHovering] = useState(false);
+	const cardRef = useRef<HTMLDivElement>(null);
 	const summary = getPostSummary(post.content);
 	const readingTime = getReadingTime(post.content);
 
@@ -54,10 +57,18 @@ export function BlogCard({ post }: BlogCardProps) {
 		<>
 			{/* デスクトップ版（lg以上）- フリップアニメーション */}
 			<div
-				className="perspective-1000 h-full hidden lg:block"
-				onMouseEnter={() => setIsFlipped(true)}
-				onMouseLeave={() => setIsFlipped(false)}
+				ref={cardRef}
+				className="perspective-1000 h-full hidden lg:block relative"
+				onMouseEnter={() => {
+					setIsFlipped(true);
+					setIsHovering(true);
+				}}
+				onMouseLeave={() => {
+					setIsFlipped(false);
+					setIsHovering(false);
+				}}
 			>
+				<CardHoverPointer isHovering={isHovering} cardRef={cardRef} />
 				<div
 					className={`relative w-full h-full transition-transform duration-700 transform-style-preserve-3d ${
 						isFlipped ? "rotate-y-180" : ""

--- a/src/components/three/HeroHoverPointer.tsx
+++ b/src/components/three/HeroHoverPointer.tsx
@@ -1,7 +1,7 @@
 // src/components/three/HeroHoverPointer.tsx
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -52,16 +52,17 @@ export function HeroHoverPointer({
 		<mesh
 			ref={meshRef}
 			position={[0, 0, 4]}
-			renderOrder={9999} // 流体エフェクト(10000)の手前
+			renderOrder={10001} // 流体エフェクト(10000)より前面
 			frustumCulled={false}
 		>
-			<circleGeometry args={[1, 32]} />
+			<circleGeometry args={[2, 32]} />
 			<meshBasicMaterial
-				color="#ffd700"
+				color="#ff0000"
 				transparent
-				opacity={0.5}
+				opacity={0.8}
 				depthTest={false}
 				depthWrite={false}
+				side={THREE.DoubleSide}
 			/>
 		</mesh>
 	);

--- a/src/components/three/HeroHoverPointer.tsx
+++ b/src/components/three/HeroHoverPointer.tsx
@@ -1,0 +1,68 @@
+// src/components/three/HeroHoverPointer.tsx
+"use client";
+
+import { useRef, useState } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+interface HeroHoverPointerProps {
+	isHovering: boolean;
+	mousePosition: THREE.Vector2;
+}
+
+/**
+ * トップページ専用のhoverポインタ
+ * カードにhoverした時にマウス位置に円を表示
+ */
+export function HeroHoverPointer({
+	isHovering,
+	mousePosition,
+}: HeroHoverPointerProps) {
+	const meshRef = useRef<THREE.Mesh>(null);
+	const targetPos = useRef(new THREE.Vector3(0, 0, 0));
+	const currentScale = useRef(0.1);
+	const { camera, size } = useThree();
+
+	useFrame((state, delta) => {
+		if (!meshRef.current) return;
+
+		// マウス位置をワールド座標に変換
+		const vec = new THREE.Vector3(mousePosition.x, mousePosition.y, 0.5);
+		vec.unproject(camera);
+
+		const dir = vec.sub(camera.position).normalize();
+		// カメラから少し手前の位置に配置（z=4の位置）
+		const distance = 4 - camera.position.z;
+		targetPos.current.copy(camera.position).add(dir.multiplyScalar(distance));
+
+		// 滑らかに追従
+		const lerp = 0.2;
+		meshRef.current.position.lerp(targetPos.current, lerp);
+
+		// hover時に拡大、それ以外は縮小
+		const targetScale = isHovering ? 0.4 : 0.01;
+		currentScale.current += (targetScale - currentScale.current) * 0.15;
+		meshRef.current.scale.setScalar(currentScale.current);
+
+		// 常にカメラの方を向く
+		meshRef.current.lookAt(camera.position);
+	});
+
+	return (
+		<mesh
+			ref={meshRef}
+			position={[0, 0, 4]}
+			renderOrder={9999} // 流体エフェクト(10000)の手前
+			frustumCulled={false}
+		>
+			<circleGeometry args={[1, 32]} />
+			<meshBasicMaterial
+				color="#ffd700"
+				transparent
+				opacity={0.5}
+				depthTest={false}
+				depthWrite={false}
+			/>
+		</mesh>
+	);
+}

--- a/src/components/three/HtmlHoverPointer.tsx
+++ b/src/components/three/HtmlHoverPointer.tsx
@@ -1,0 +1,64 @@
+// src/components/three/HtmlHoverPointer.tsx
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+
+interface HtmlHoverPointerProps {
+	isHovering: boolean;
+}
+
+/**
+ * HTMLレイヤーで表示するhoverポインタ
+ * 流体エフェクトの影響を受けない
+ */
+export function HtmlHoverPointer({ isHovering }: HtmlHoverPointerProps) {
+	const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+	const [scale, setScale] = useState(0);
+	const rafRef = useRef<number>();
+
+	useEffect(() => {
+		const handleMouseMove = (e: MouseEvent) => {
+			setMousePos({ x: e.clientX, y: e.clientY });
+		};
+
+		window.addEventListener("mousemove", handleMouseMove);
+		return () => window.removeEventListener("mousemove", handleMouseMove);
+	}, []);
+
+	useEffect(() => {
+		const targetScale = isHovering ? 1 : 0;
+
+		const animate = () => {
+			setScale((prev) => {
+				const diff = targetScale - prev;
+				if (Math.abs(diff) < 0.01) return targetScale;
+				return prev + diff * 0.15;
+			});
+			rafRef.current = requestAnimationFrame(animate);
+		};
+
+		rafRef.current = requestAnimationFrame(animate);
+
+		return () => {
+			if (rafRef.current) cancelAnimationFrame(rafRef.current);
+		};
+	}, [isHovering]);
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				left: mousePos.x,
+				top: mousePos.y,
+				width: "80px",
+				height: "80px",
+				borderRadius: "50%",
+				backgroundColor: "rgba(255, 215, 0, 0.6)",
+				transform: `translate(-50%, -50%) scale(${scale})`,
+				pointerEvents: "none",
+				zIndex: 9999,
+				transition: "transform 0.1s ease-out",
+			}}
+		/>
+	);
+}

--- a/src/components/three/HtmlHoverPointer.tsx
+++ b/src/components/three/HtmlHoverPointer.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState, useRef } from "react";
 
 interface HtmlHoverPointerProps {
-	isHovering: boolean;
+  isHovering: boolean;
 }
 
 /**
@@ -12,53 +12,61 @@ interface HtmlHoverPointerProps {
  * 流体エフェクトの影響を受けない
  */
 export function HtmlHoverPointer({ isHovering }: HtmlHoverPointerProps) {
-	const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
-	const [scale, setScale] = useState(0);
-	const rafRef = useRef<number>();
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+  const [scale, setScale] = useState(0);
+  const rafRef = useRef<number | undefined>(undefined);
 
-	useEffect(() => {
-		const handleMouseMove = (e: MouseEvent) => {
-			setMousePos({ x: e.clientX, y: e.clientY });
-		};
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      setMousePos({ x: e.clientX, y: e.clientY });
+    };
 
-		window.addEventListener("mousemove", handleMouseMove);
-		return () => window.removeEventListener("mousemove", handleMouseMove);
-	}, []);
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => window.removeEventListener("mousemove", handleMouseMove);
+  }, []);
 
-	useEffect(() => {
-		const targetScale = isHovering ? 1 : 0;
+  useEffect(() => {
+    const targetScale = isHovering ? 1 : 0;
 
-		const animate = () => {
-			setScale((prev) => {
-				const diff = targetScale - prev;
-				if (Math.abs(diff) < 0.01) return targetScale;
-				return prev + diff * 0.15;
-			});
-			rafRef.current = requestAnimationFrame(animate);
-		};
+    const animate = () => {
+      setScale((prev) => {
+        const diff = targetScale - prev;
+        if (Math.abs(diff) < 0.01) return targetScale;
+        return prev + diff * 0.15;
+      });
+      rafRef.current = requestAnimationFrame(animate);
+    };
 
-		rafRef.current = requestAnimationFrame(animate);
+    rafRef.current = requestAnimationFrame(animate);
 
-		return () => {
-			if (rafRef.current) cancelAnimationFrame(rafRef.current);
-		};
-	}, [isHovering]);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [isHovering]);
 
-	return (
-		<div
-			style={{
-				position: "fixed",
-				left: mousePos.x,
-				top: mousePos.y,
-				width: "80px",
-				height: "80px",
-				borderRadius: "50%",
-				backgroundColor: "rgba(255, 215, 0, 0.6)",
-				transform: `translate(-50%, -50%) scale(${scale})`,
-				pointerEvents: "none",
-				zIndex: 9999,
-				transition: "transform 0.1s ease-out",
-			}}
-		/>
-	);
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: mousePos.x,
+        top: mousePos.y,
+        width: "80px",
+        height: "80px",
+        borderRadius: "50%",
+        backgroundColor: "rgba(255, 215, 0, 0.6)",
+        transform: `translate(-50%, -50%) scale(${scale})`,
+        pointerEvents: "none",
+        zIndex: 9999,
+        transition: "transform 0.1s ease-out",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "white",
+        fontWeight: "bold",
+        fontSize: "14px",
+      }}
+    >
+      click
+    </div>
+  );
 }

--- a/src/components/three/VideoCard3D.tsx
+++ b/src/components/three/VideoCard3D.tsx
@@ -47,6 +47,7 @@ export default function VideoCard3D({
 	const videoTexture = useRef<VideoTexture | null>(null);
 	const imageTexture = useRef<THREE.Texture | null>(null);
 	const [textureLoaded, setTextureLoaded] = useState(false);
+	const isHoveringRef = useRef(false);
 
 	// === 角丸アルファ ===
 	const alphaTexture = useMemo(() => {
@@ -269,6 +270,15 @@ export default function VideoCard3D({
 		if (meshRef.current)
 			(meshRef.current.material as THREE.MeshBasicMaterial).opacity =
 				drawOpacity;
+
+		// hover状態の自動リセット: opacityが低い時にhoverしていたら強制的にfalseにする
+		if (isHoveringRef.current && drawOpacity <= 0.5) {
+			isHoveringRef.current = false;
+			document.body.style.cursor = "default";
+			if (onHoverChange) {
+				onHoverChange(false);
+			}
+		}
 	});
 
 	// === 描画（単一メッシュ / DoubleSide） ===
@@ -291,7 +301,8 @@ export default function VideoCard3D({
 							onPointerOver={(e) => {
 								e.stopPropagation();
 								// カードが十分に表示されている時だけhoverイベントを発火
-								if (opacity > 0.5) {
+								if (drawOpacity > 0.5) {
+									isHoveringRef.current = true;
 									document.body.style.cursor = "pointer";
 									if (onHoverChange) {
 										onHoverChange(true);
@@ -300,11 +311,11 @@ export default function VideoCard3D({
 							}}
 							onPointerOut={(e) => {
 								e.stopPropagation();
-								if (opacity > 0.5) {
-									document.body.style.cursor = "default";
-									if (onHoverChange) {
-										onHoverChange(false);
-									}
+								// onPointerOutは常に実行してhover状態をリセット
+								isHoveringRef.current = false;
+								document.body.style.cursor = "default";
+								if (onHoverChange) {
+									onHoverChange(false);
 								}
 							}}
 						>

--- a/src/components/three/VideoCard3D.tsx
+++ b/src/components/three/VideoCard3D.tsx
@@ -20,6 +20,7 @@ interface VideoCard3DProps {
 	cornerRadiusPx?: number;
 	displayHeightPx?: number;
 	onClick?: () => void;
+	onHoverChange?: (isHovering: boolean) => void;
 }
 
 export default function VideoCard3D({
@@ -36,6 +37,7 @@ export default function VideoCard3D({
 	cornerRadiusPx = 5,
 	displayHeightPx = 400,
 	onClick,
+	onHoverChange,
 }: VideoCard3DProps) {
 	const meshRef = useRef<THREE.Mesh>(null);
 	const exitGroupRef = useRef<THREE.Group>(null);
@@ -289,10 +291,16 @@ export default function VideoCard3D({
 							onPointerOver={(e) => {
 								e.stopPropagation();
 								document.body.style.cursor = "pointer";
+								if (onHoverChange) {
+									onHoverChange(true);
+								}
 							}}
 							onPointerOut={(e) => {
 								e.stopPropagation();
 								document.body.style.cursor = "default";
+								if (onHoverChange) {
+									onHoverChange(false);
+								}
 							}}
 						>
 							<primitive object={curvedPlaneGeometry} attach="geometry" />

--- a/src/components/three/VideoCard3D.tsx
+++ b/src/components/three/VideoCard3D.tsx
@@ -290,16 +290,21 @@ export default function VideoCard3D({
 							}}
 							onPointerOver={(e) => {
 								e.stopPropagation();
-								document.body.style.cursor = "pointer";
-								if (onHoverChange) {
-									onHoverChange(true);
+								// カードが十分に表示されている時だけhoverイベントを発火
+								if (opacity > 0.5) {
+									document.body.style.cursor = "pointer";
+									if (onHoverChange) {
+										onHoverChange(true);
+									}
 								}
 							}}
 							onPointerOut={(e) => {
 								e.stopPropagation();
-								document.body.style.cursor = "default";
-								if (onHoverChange) {
-									onHoverChange(false);
+								if (opacity > 0.5) {
+									document.body.style.cursor = "default";
+									if (onHoverChange) {
+										onHoverChange(false);
+									}
 								}
 							}}
 						>

--- a/src/components/three/VideoCard3D.tsx
+++ b/src/components/three/VideoCard3D.tsx
@@ -117,10 +117,10 @@ export default function VideoCard3D({
 
 			v.onerror = (e) => {
 				console.error(`❌ [${title}] 動画読み込みエラー:`, videoSrc);
-				console.error('Error details:', e);
-				console.error('Video element:', v);
-				console.error('NetworkState:', v.networkState);
-				console.error('ReadyState:', v.readyState);
+				console.error("Error details:", e);
+				console.error("Video element:", v);
+				console.error("NetworkState:", v.networkState);
+				console.error("ReadyState:", v.readyState);
 			};
 
 			const tex = new VideoTexture(v);

--- a/src/components/three/VideoCardsRenderer.tsx
+++ b/src/components/three/VideoCardsRenderer.tsx
@@ -59,6 +59,7 @@ interface VideoCardsRendererProps {
 	requiredTurns: number;
 	ROT_TURNS: number;
 	onCardClick?: (slide: VideoSlide, index: number) => void;
+	onCardHover?: (isHovering: boolean) => void;
 }
 
 export default function VideoCardsRenderer({
@@ -68,6 +69,7 @@ export default function VideoCardsRenderer({
 	requiredTurns,
 	ROT_TURNS,
 	onCardClick,
+	onCardHover,
 }: VideoCardsRendererProps) {
 	const phaseLin = THREE.MathUtils.clamp(
 		(scrollProgress - THIRD_PHASE_START) /
@@ -151,6 +153,7 @@ export default function VideoCardsRenderer({
 						scale={0.7}
 						opacity={opacity}
 						onClick={() => onCardClick?.(slide, index)}
+						onHoverChange={onCardHover}
 					/>
 				);
 			})}

--- a/src/components/three/card-hover-pointer.tsx
+++ b/src/components/three/card-hover-pointer.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useRef, useState, useEffect } from "react";
+import type { Mesh } from "three";
+
+interface CardHoverPointerProps {
+	isHovering: boolean;
+	cardRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function HoverCircle({ isHovering, cardRef }: CardHoverPointerProps) {
+	const meshRef = useRef<Mesh>(null);
+	const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+
+	useEffect(() => {
+		const handleMouseMove = (event: MouseEvent) => {
+			if (!cardRef.current) return;
+
+			const rect = cardRef.current.getBoundingClientRect();
+
+			// カード内の相対座標に変換
+			const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+			const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+			setMousePosition({ x, y });
+		};
+
+		if (isHovering) {
+			window.addEventListener("mousemove", handleMouseMove);
+		}
+
+		return () => {
+			window.removeEventListener("mousemove", handleMouseMove);
+		};
+	}, [isHovering, cardRef]);
+
+	useFrame(() => {
+		if (meshRef.current) {
+			// マウス位置に追従
+			const lerp = 0.15;
+			meshRef.current.position.x +=
+				(mousePosition.x * 2 - meshRef.current.position.x) * lerp;
+			meshRef.current.position.y +=
+				(mousePosition.y * 2 - meshRef.current.position.y) * lerp;
+
+			// hover時に拡大
+			const targetScale = isHovering ? 1.5 : 0.1;
+			const currentScale = meshRef.current.scale.x;
+			const newScale = currentScale + (targetScale - currentScale) * 0.1;
+
+			meshRef.current.scale.setScalar(newScale);
+		}
+	});
+
+	return (
+		<mesh ref={meshRef} position={[0, 0, 0]}>
+			<circleGeometry args={[0.5, 32]} />
+			<meshBasicMaterial color="#ffd700" transparent opacity={0.4} />
+		</mesh>
+	);
+}
+
+export function CardHoverPointer({
+	isHovering,
+	cardRef,
+}: CardHoverPointerProps) {
+	const [isClient, setIsClient] = useState(false);
+	const [isMobile, setIsMobile] = useState(true);
+
+	useEffect(() => {
+		setIsClient(true);
+		const checkMobile = () => {
+			setIsMobile(window.innerWidth < 768 || "ontouchstart" in window);
+		};
+
+		checkMobile();
+		window.addEventListener("resize", checkMobile);
+
+		return () => window.removeEventListener("resize", checkMobile);
+	}, []);
+
+	if (!isClient || isMobile) {
+		return null;
+	}
+
+	return (
+		<div className="absolute inset-0 z-10" style={{ pointerEvents: "none" }}>
+			<Canvas
+				className="w-full h-full"
+				camera={{ position: [0, 0, 5], fov: 75 }}
+				style={{ pointerEvents: "none" }}
+			>
+				<HoverCircle isHovering={isHovering} cardRef={cardRef} />
+			</Canvas>
+		</div>
+	);
+}

--- a/src/components/three/card-hover-pointer.tsx
+++ b/src/components/three/card-hover-pointer.tsx
@@ -85,7 +85,7 @@ export function CardHoverPointer({
 	}
 
 	return (
-		<div className="absolute inset-0 z-10" style={{ pointerEvents: "none" }}>
+		<div className="absolute inset-0 z-50" style={{ pointerEvents: "none" }}>
 			<Canvas
 				className="w-full h-full"
 				camera={{ position: [0, 0, 5], fov: 75 }}

--- a/src/components/three/hero-canvas.tsx
+++ b/src/components/three/hero-canvas.tsx
@@ -4,12 +4,12 @@
 import { Canvas, useFrame } from "@react-three/fiber";
 import { useFBO } from "@react-three/drei";
 import {
-  useRef,
-  useMemo,
-  Suspense,
-  type ReactNode,
-  useState,
-  useEffect,
+	useRef,
+	useMemo,
+	Suspense,
+	type ReactNode,
+	useState,
+	useEffect,
 } from "react";
 import * as THREE from "three";
 import { StarParticles } from "./StarParticles";
@@ -59,34 +59,34 @@ const HIDE_BG_AT_T = 0.98;
 
 // ===== ユーティリティ =====
 const smooth01 = (x: number) => {
-  const t = THREE.MathUtils.clamp(x, 0, 1);
-  return t * t * (3 - 2 * t);
+	const t = THREE.MathUtils.clamp(x, 0, 1);
+	return t * t * (3 - 2 * t);
 };
 const sstep = (x: number, a: number, b: number) =>
-  THREE.MathUtils.clamp((x - a) / Math.max(1e-6, b - a), 0, 1);
+	THREE.MathUtils.clamp((x - a) / Math.max(1e-6, b - a), 0, 1);
 
 function dwellWithOffset(
-  theta: number,
-  slotStep: number,
-  dwellFrac: number,
-  offset: number
+	theta: number,
+	slotStep: number,
+	dwellFrac: number,
+	offset: number,
 ) {
-  if (slotStep <= 0) return theta;
-  const s = slotStep;
-  const holdHalf = Math.min(0.5, Math.max(0, dwellFrac * 0.5));
-  const nearestCenter = offset + Math.round((theta - offset) / s) * s;
-  const s2 = s * 0.5;
-  let d = theta - nearestCenter;
-  if (d > s2) d -= s;
-  if (d < -s2) d += s;
-  const absd = Math.abs(d);
-  const holdWidth = holdHalf * s;
-  if (absd <= holdWidth) return nearestCenter;
-  const moveRange = s2 - holdWidth;
-  const t = (absd - holdWidth) / Math.max(1e-6, moveRange);
-  const eased = smooth01(t);
-  const newAbs = holdWidth + eased * moveRange;
-  return nearestCenter + Math.sign(d) * newAbs;
+	if (slotStep <= 0) return theta;
+	const s = slotStep;
+	const holdHalf = Math.min(0.5, Math.max(0, dwellFrac * 0.5));
+	const nearestCenter = offset + Math.round((theta - offset) / s) * s;
+	const s2 = s * 0.5;
+	let d = theta - nearestCenter;
+	if (d > s2) d -= s;
+	if (d < -s2) d += s;
+	const absd = Math.abs(d);
+	const holdWidth = holdHalf * s;
+	if (absd <= holdWidth) return nearestCenter;
+	const moveRange = s2 - holdWidth;
+	const t = (absd - holdWidth) / Math.max(1e-6, moveRange);
+	const eased = smooth01(t);
+	const newAbs = holdWidth + eased * moveRange;
+	return nearestCenter + Math.sign(d) * newAbs;
 }
 
 // ===== カード大きさ =====
@@ -95,533 +95,533 @@ const CARD_H = 0.7;
 
 // ===== ヒーローシーン =====
 interface HeroSceneProps {
-  scrollProgress: number;
-  videoSlides: VideoSlide[];
-  onCardClick?: (slide: VideoSlide, index: number) => void;
+	scrollProgress: number;
+	videoSlides: VideoSlide[];
+	onCardClick?: (slide: VideoSlide, index: number) => void;
 }
 
 function HeroScene({
-  scrollProgress,
-  videoSlides,
-  onCardClick,
+	scrollProgress,
+	videoSlides,
+	onCardClick,
 }: HeroSceneProps) {
-  const heroMatRef = useRef<any>(null);
-  const starGroupRef = useRef<THREE.Group>(null);
-  const triangleGroupRef = useRef<THREE.Group>(null);
-  const triangleVisibleMeshRef = useRef<THREE.Mesh>(null);
-  const lineSegmentsRef = useRef<THREE.LineSegments>(null);
-  const circleRef = useRef<THREE.Mesh>(null);
-  const videoCardsRef = useRef<THREE.Group>(null);
-  const rootRef = useRef<THREE.Group>(null);
+	const heroMatRef = useRef<any>(null);
+	const starGroupRef = useRef<THREE.Group>(null);
+	const triangleGroupRef = useRef<THREE.Group>(null);
+	const triangleVisibleMeshRef = useRef<THREE.Mesh>(null);
+	const lineSegmentsRef = useRef<THREE.LineSegments>(null);
+	const circleRef = useRef<THREE.Mesh>(null);
+	const videoCardsRef = useRef<THREE.Group>(null);
+	const rootRef = useRef<THREE.Group>(null);
 
-  // 黒円マテリアル
-  const featherMat = useMemo(() => {
-    const m = new (FeatherCircleMaterial as any)();
-    m.transparent = true;
-    m.depthTest = false;
-    m.depthWrite = false;
-    if (m.uniforms?.uFeather) m.uniforms.uFeather.value = CIRCLE_FEATHER;
-    return m;
-  }, []);
+	// 黒円マテリアル
+	const featherMat = useMemo(() => {
+		const m = new (FeatherCircleMaterial as any)();
+		m.transparent = true;
+		m.depthTest = false;
+		m.depthWrite = false;
+		if (m.uniforms?.uFeather) m.uniforms.uFeather.value = CIRCLE_FEATHER;
+		return m;
+	}, []);
 
-  // 画面歪み（FBO合成）
-  const fluidRef = useRef<THREE.Mesh>(null);
-  const hoverMatRef = useRef<any>(null);
-  const fbo = useFBO({ samples: 4 });
+	// 画面歪み（FBO合成）
+	const fluidRef = useRef<THREE.Mesh>(null);
+	const hoverMatRef = useRef<any>(null);
+	const fbo = useFBO({ samples: 4 });
 
-  // FBO を Linear に（色ズレ防止）
-  useEffect(() => {
-    fbo.texture.colorSpace = THREE.LinearSRGBColorSpace;
-  }, [fbo]);
+	// FBO を Linear に（色ズレ防止）
+	useEffect(() => {
+		fbo.texture.colorSpace = THREE.LinearSRGBColorSpace;
+	}, [fbo]);
 
-  // ====== ポインタの指数平滑 ======
-  const mouseRaw = useRef(new THREE.Vector2(0.5, 0.5));
-  const mouseFiltered = useRef(new THREE.Vector2(0.5, 0.5));
-  const lastMouseFiltered = useRef(new THREE.Vector2(0.5, 0.5));
-  const velSmoothed = useRef(new THREE.Vector2(0, 0));
-  const hoverStrength = useRef(0);
+	// ====== ポインタの指数平滑 ======
+	const mouseRaw = useRef(new THREE.Vector2(0.5, 0.5));
+	const mouseFiltered = useRef(new THREE.Vector2(0.5, 0.5));
+	const lastMouseFiltered = useRef(new THREE.Vector2(0.5, 0.5));
+	const velSmoothed = useRef(new THREE.Vector2(0, 0));
+	const hoverStrength = useRef(0);
 
-  useEffect(() => {
-    const onMove = (e: PointerEvent) => {
-      mouseRaw.current.set(
-        e.clientX / window.innerWidth,
-        1 - e.clientY / window.innerHeight
-      );
-      hoverStrength.current = 1;
-    };
-    window.addEventListener("pointermove", onMove, { passive: true });
-    return () => window.removeEventListener("pointermove", onMove);
-  }, []);
+	useEffect(() => {
+		const onMove = (e: PointerEvent) => {
+			mouseRaw.current.set(
+				e.clientX / window.innerWidth,
+				1 - e.clientY / window.innerHeight,
+			);
+			hoverStrength.current = 1;
+		};
+		window.addEventListener("pointermove", onMove, { passive: true });
+		return () => window.removeEventListener("pointermove", onMove);
+	}, []);
 
-  // 並び（時計回り）
-  const gateAngle = -Math.PI / 2;
-  const halfDiagCard = Math.sqrt(CARD_W ** 2 + CARD_H ** 2) / 2;
-  const orbitRadius = tetraRadius + halfDiagCard + 0.25;
+	// 並び（時計回り）
+	const gateAngle = -Math.PI / 2;
+	const halfDiagCard = Math.sqrt(CARD_W ** 2 + CARD_H ** 2) / 2;
+	const orbitRadius = tetraRadius + halfDiagCard + 0.25;
 
-  const layout = useMemo(() => {
-    const n = Math.max(1, videoSlides.length);
-    const slotStep = TAU / n;
-    const items = Array.from({ length: n }, (_, i) => {
-      const angle = gateAngle - (i / n) * TAU; // 時計回り配置
-      const x = Math.sin(angle) * orbitRadius;
-      const z = Math.cos(angle) * orbitRadius;
-      return { index: i, angle, x, z, rank: i };
-    });
-    return { n, items, slotStep };
-  }, [orbitRadius, videoSlides.length]);
+	const layout = useMemo(() => {
+		const n = Math.max(1, videoSlides.length);
+		const slotStep = TAU / n;
+		const items = Array.from({ length: n }, (_, i) => {
+			const angle = gateAngle - (i / n) * TAU; // 時計回り配置
+			const x = Math.sin(angle) * orbitRadius;
+			const z = Math.cos(angle) * orbitRadius;
+			return { index: i, angle, x, z, rank: i };
+		});
+		return { n, items, slotStep };
+	}, [orbitRadius, videoSlides.length]);
 
-  // third-phase 開始〜終了のマッピング
-  const thirdPhaseAtStart =
-    (VIDEO_START_PROGRESS - THIRD_PHASE_START) /
-    (THIRD_PHASE_END - THIRD_PHASE_START);
-  const thirdPhaseAtStartEased = smooth01(thirdPhaseAtStart) ** VIDEO_EASE;
-  const availablePhaseEased = Math.max(0, 1 - thirdPhaseAtStartEased);
+	// third-phase 開始〜終了のマッピング
+	const thirdPhaseAtStart =
+		(VIDEO_START_PROGRESS - THIRD_PHASE_START) /
+		(THIRD_PHASE_END - THIRD_PHASE_START);
+	const thirdPhaseAtStartEased = smooth01(thirdPhaseAtStart) ** VIDEO_EASE;
+	const availablePhaseEased = Math.max(0, 1 - thirdPhaseAtStartEased);
 
-  // 退場まで必要な回転数
-  const requiredTurns = useMemo(() => {
-    const { n } = layout;
-    const fadeTurnsLast = (n - 1 + FADE_FRAC) / n;
-    return 1 + GAP_TURNS + fadeTurnsLast;
-  }, [layout]);
+	// 退場まで必要な回転数
+	const requiredTurns = useMemo(() => {
+		const { n } = layout;
+		const fadeTurnsLast = (n - 1 + FADE_FRAC) / n;
+		return 1 + GAP_TURNS + fadeTurnsLast;
+	}, [layout]);
 
-  // ===== 完走する回転数 =====
-  const ROT_TURNS = useMemo(() => {
-    return (requiredTurns / Math.max(0.0001, availablePhaseEased)) * 1.05;
-  }, [requiredTurns, availablePhaseEased]);
+	// ===== 完走する回転数 =====
+	const ROT_TURNS = useMemo(() => {
+		return (requiredTurns / Math.max(0.0001, availablePhaseEased)) * 1.05;
+	}, [requiredTurns, availablePhaseEased]);
 
-  // 装飾ライン
-  const lineGeometry = useMemo(() => {
-    const geometry = new THREE.TetrahedronGeometry(tetraRadius, 0);
-    const position = geometry.attributes.position as THREE.BufferAttribute;
-    const colors: number[] = [];
-    const color = new THREE.Color();
-    for (let i = 0; i < position.count; i++) {
-      const hue = position.getY(i) / (tetraRadius * 2) + 0.5;
-      color.setHSL(hue, 1.0, 0.5);
-      colors.push(color.r, color.g, color.b);
-    }
-    geometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
-    return geometry;
-  }, []);
-  const lineSegments = useMemo(
-    () =>
-      new THREE.LineSegments(
-        lineGeometry,
-        new THREE.LineBasicMaterial({ vertexColors: true })
-      ),
-    [lineGeometry]
-  );
+	// 装飾ライン
+	const lineGeometry = useMemo(() => {
+		const geometry = new THREE.TetrahedronGeometry(tetraRadius, 0);
+		const position = geometry.attributes.position as THREE.BufferAttribute;
+		const colors: number[] = [];
+		const color = new THREE.Color();
+		for (let i = 0; i < position.count; i++) {
+			const hue = position.getY(i) / (tetraRadius * 2) + 0.5;
+			color.setHSL(hue, 1.0, 0.5);
+			colors.push(color.r, color.g, color.b);
+		}
+		geometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
+		return geometry;
+	}, []);
+	const lineSegments = useMemo(
+		() =>
+			new THREE.LineSegments(
+				lineGeometry,
+				new THREE.LineBasicMaterial({ vertexColors: true }),
+			),
+		[lineGeometry],
+	);
 
-  // 慣性
-  const smoothedTheta = useRef(0);
-  const circleTRef = useRef(0);
+	// 慣性
+	const smoothedTheta = useRef(0);
+	const circleTRef = useRef(0);
 
-  // ヒーロー領域算出ワーク
-  const box = useMemo(() => new THREE.Box3(), []);
-  const tmp = useMemo(() => new THREE.Vector3(), []);
-  const corners = useMemo(
-    () => Array.from({ length: 8 }, () => new THREE.Vector3()),
-    []
-  );
+	// ヒーロー領域算出ワーク
+	const box = useMemo(() => new THREE.Box3(), []);
+	const tmp = useMemo(() => new THREE.Vector3(), []);
+	const corners = useMemo(
+		() => Array.from({ length: 8 }, () => new THREE.Vector3()),
+		[],
+	);
 
-  // ===== 毎フレーム =====
-  useFrame((state, delta) => {
-    // 1) FBO描画（液体メッシュは一時非表示）
-    if (fluidRef.current) {
-      const wasVisible = fluidRef.current.visible;
-      fluidRef.current.visible = false;
-      state.gl.setRenderTarget(fbo);
-      state.gl.clear();
-      state.gl.render(state.scene, state.camera);
-      state.gl.setRenderTarget(null);
-      fluidRef.current.visible = wasVisible;
-    }
+	// ===== 毎フレーム =====
+	useFrame((state, delta) => {
+		// 1) FBO描画（液体メッシュは一時非表示）
+		if (fluidRef.current) {
+			const wasVisible = fluidRef.current.visible;
+			fluidRef.current.visible = false;
+			state.gl.setRenderTarget(fbo);
+			state.gl.clear();
+			state.gl.render(state.scene, state.camera);
+			state.gl.setRenderTarget(null);
+			fluidRef.current.visible = wasVisible;
+		}
 
-    // ポインタ・速度の指数平滑
-    const kMouse = 1 - Math.exp(-delta * 12.0);
-    mouseFiltered.current.lerp(mouseRaw.current, kMouse);
+		// ポインタ・速度の指数平滑
+		const kMouse = 1 - Math.exp(-delta * 12.0);
+		mouseFiltered.current.lerp(mouseRaw.current, kMouse);
 
-    const velNow = new THREE.Vector2()
-      .subVectors(mouseFiltered.current, lastMouseFiltered.current)
-      .multiplyScalar(1 / Math.max(1e-6, delta));
-    const kVel = 1 - Math.exp(-delta * 20.0);
-    velSmoothed.current.lerp(velNow, kVel);
-    lastMouseFiltered.current.copy(mouseFiltered.current);
+		const velNow = new THREE.Vector2()
+			.subVectors(mouseFiltered.current, lastMouseFiltered.current)
+			.multiplyScalar(1 / Math.max(1e-6, delta));
+		const kVel = 1 - Math.exp(-delta * 20.0);
+		velSmoothed.current.lerp(velNow, kVel);
+		lastMouseFiltered.current.copy(mouseFiltered.current);
 
-    // HoverFluid のヒーロー領域更新
-    const u = hoverMatRef.current?.uniforms;
-    if (u) {
-      let minX = 1,
-        minY = 1;
-      let maxX = -1,
-        maxY = -1;
-      box.makeEmpty();
-      if (triangleGroupRef.current)
-        box.expandByObject(triangleGroupRef.current);
-      if (videoCardsRef.current) box.expandByObject(videoCardsRef.current);
+		// HoverFluid のヒーロー領域更新
+		const u = hoverMatRef.current?.uniforms;
+		if (u) {
+			let minX = 1,
+				minY = 1;
+			let maxX = -1,
+				maxY = -1;
+			box.makeEmpty();
+			if (triangleGroupRef.current)
+				box.expandByObject(triangleGroupRef.current);
+			if (videoCardsRef.current) box.expandByObject(videoCardsRef.current);
 
-      const bmin = box.min,
-        bmax = box.max;
-      const pts = corners;
-      pts[0].set(bmin.x, bmin.y, bmin.z);
-      pts[1].set(bmax.x, bmin.y, bmin.z);
-      pts[2].set(bmin.x, bmax.y, bmin.z);
-      pts[3].set(bmax.x, bmax.y, bmin.z);
-      pts[4].set(bmin.x, bmin.y, bmax.z);
-      pts[5].set(bmax.x, bmin.y, bmax.z);
-      pts[6].set(bmin.x, bmax.y, bmax.z);
-      pts[7].set(bmax.x, bmax.y, bmax.z);
+			const bmin = box.min,
+				bmax = box.max;
+			const pts = corners;
+			pts[0].set(bmin.x, bmin.y, bmin.z);
+			pts[1].set(bmax.x, bmin.y, bmin.z);
+			pts[2].set(bmin.x, bmax.y, bmin.z);
+			pts[3].set(bmax.x, bmax.y, bmin.z);
+			pts[4].set(bmin.x, bmin.y, bmax.z);
+			pts[5].set(bmax.x, bmin.y, bmax.z);
+			pts[6].set(bmin.x, bmax.y, bmax.z);
+			pts[7].set(bmax.x, bmax.y, bmax.z);
 
-      for (let i = 0; i < 8; i++) {
-        tmp.copy(pts[i]).project(state.camera);
-        minX = Math.min(minX, tmp.x);
-        maxX = Math.max(maxX, tmp.x);
-        minY = Math.min(minY, tmp.y);
-        maxY = Math.max(maxY, tmp.y);
-      }
+			for (let i = 0; i < 8; i++) {
+				tmp.copy(pts[i]).project(state.camera);
+				minX = Math.min(minX, tmp.x);
+				maxX = Math.max(maxX, tmp.x);
+				minY = Math.min(minY, tmp.y);
+				maxY = Math.max(maxY, tmp.y);
+			}
 
-      const cx = (minX + maxX) * 0.5 + 0.5;
-      const cy = (minY + maxY) * 0.5 + 0.5;
-      const hx = (maxX - minX) * 0.5;
-      const hy = (maxY - minY) * 0.5;
+			const cx = (minX + maxX) * 0.5 + 0.5;
+			const cy = (minY + maxY) * 0.5 + 0.5;
+			const hx = (maxX - minX) * 0.5;
+			const hy = (maxY - minY) * 0.5;
 
-      const dpr = state.gl.getPixelRatio();
-      u.uTime.value += delta;
-      u.uScene.value = fbo.texture;
-      u.uResolution.value.set(state.size.width * dpr, state.size.height * dpr);
+			const dpr = state.gl.getPixelRatio();
+			u.uTime.value += delta;
+			u.uScene.value = fbo.texture;
+			u.uResolution.value.set(state.size.width * dpr, state.size.height * dpr);
 
-      u.uMouse.value.copy(mouseFiltered.current);
-      u.uVel.value.copy(velSmoothed.current);
+			u.uMouse.value.copy(mouseFiltered.current);
+			u.uVel.value.copy(velSmoothed.current);
 
-      hoverStrength.current = Math.max(0, hoverStrength.current - delta * 1.6);
-      const kInt = 1 - Math.exp(-delta * 6.0);
-      u.uIntensity.value += (hoverStrength.current - u.uIntensity.value) * kInt;
+			hoverStrength.current = Math.max(0, hoverStrength.current - delta * 1.6);
+			const kInt = 1 - Math.exp(-delta * 6.0);
+			u.uIntensity.value += (hoverStrength.current - u.uIntensity.value) * kInt;
 
-      // 少しソフト寄り
-      u.uRadius.value = 0.095;
-      u.uFalloff.value = 0.165;
-      u.uDispAmp.value = 0.045;
-      u.uNoiseAmp.value = 0.38;
+			// 少しソフト寄り
+			u.uRadius.value = 0.095;
+			u.uFalloff.value = 0.165;
+			u.uDispAmp.value = 0.045;
+			u.uNoiseAmp.value = 0.38;
 
-      u.uBaseAmp.value = 0.013;
-      u.uBaseScale.value = 1.18;
+			u.uBaseAmp.value = 0.013;
+			u.uBaseScale.value = 1.18;
 
-      u.uHeroCenter.value.set(
-        THREE.MathUtils.clamp(cx, 0.0, 1.0),
-        THREE.MathUtils.clamp(cy, 0.0, 1.0)
-      );
-      u.uHeroSize.value.set(
-        THREE.MathUtils.clamp(hx + 0.15, 0.0, 0.8),
-        THREE.MathUtils.clamp(hy + 0.15, 0.0, 0.8)
-      );
-      u.uHeroRadius.value = 0.06;
-      u.uChromAb.value = 0.0;
-      // 一時的にデバッグモードを有効化
-      u.uShowMask.value = 0; // 0: エフェクト表示, 1: デバッグ表示
-    }
+			u.uHeroCenter.value.set(
+				THREE.MathUtils.clamp(cx, 0.0, 1.0),
+				THREE.MathUtils.clamp(cy, 0.0, 1.0),
+			);
+			u.uHeroSize.value.set(
+				THREE.MathUtils.clamp(hx + 0.15, 0.0, 0.8),
+				THREE.MathUtils.clamp(hy + 0.15, 0.0, 0.8),
+			);
+			u.uHeroRadius.value = 0.06;
+			u.uChromAb.value = 0.0;
+			// 一時的にデバッグモードを有効化
+			u.uShowMask.value = 0; // 0: エフェクト表示, 1: デバッグ表示
+		}
 
-    // シェーダ時間/解像度
-    if (heroMatRef.current) {
-      heroMatRef.current.uniforms.uTime.value += delta;
-      heroMatRef.current.uniforms.uMouse.value = [0, 0];
-      heroMatRef.current.uniforms.uResolution.value = [
-        state.size.width,
-        state.size.height,
-      ];
-    }
-    if (rootRef.current) {
-      rootRef.current.scale.set(SCENE_SCALE, SCENE_SCALE, SCENE_SCALE);
-      rootRef.current.position.z = ROOT_Z_OFFSET;
-    }
+		// シェーダ時間/解像度
+		if (heroMatRef.current) {
+			heroMatRef.current.uniforms.uTime.value += delta;
+			heroMatRef.current.uniforms.uMouse.value = [0, 0];
+			heroMatRef.current.uniforms.uResolution.value = [
+				state.size.width,
+				state.size.height,
+			];
+		}
+		if (rootRef.current) {
+			rootRef.current.scale.set(SCENE_SCALE, SCENE_SCALE, SCENE_SCALE);
+			rootRef.current.position.z = ROOT_Z_OFFSET;
+		}
 
-    // テトラ回転＆スケール
-    if (triangleGroupRef.current) {
-      triangleGroupRef.current.rotation.x += delta * 0.1;
-      triangleGroupRef.current.rotation.y += delta * 0.2;
+		// テトラ回転＆スケール
+		if (triangleGroupRef.current) {
+			triangleGroupRef.current.rotation.x += delta * 0.1;
+			triangleGroupRef.current.rotation.y += delta * 0.2;
 
-      if (scrollProgress < THIRD_PHASE_START) {
-        triangleGroupRef.current.scale.set(1, 1, 1);
-      } else if (scrollProgress <= 0.55) {
-        const t =
-          (scrollProgress - THIRD_PHASE_START) / (0.55 - THIRD_PHASE_START);
-        const s = THREE.MathUtils.lerp(1.0, 0.7, smooth01(t));
-        triangleGroupRef.current.scale.set(s, s, s);
-      } else if (scrollProgress < RETURN_SCROLL_START) {
-        triangleGroupRef.current.scale.set(0.7, 0.7, 0.7);
-      } else if (scrollProgress <= RETURN_SCROLL_END) {
-        const tUp = sstep(
-          scrollProgress,
-          RETURN_SCROLL_START,
-          RETURN_SCROLL_END
-        );
-        const s = THREE.MathUtils.lerp(0.7, 1.0, smooth01(tUp));
-        triangleGroupRef.current.scale.set(s, s, s);
-      } else {
-        triangleGroupRef.current.scale.set(1, 1, 1);
-      }
-    }
+			if (scrollProgress < THIRD_PHASE_START) {
+				triangleGroupRef.current.scale.set(1, 1, 1);
+			} else if (scrollProgress <= 0.55) {
+				const t =
+					(scrollProgress - THIRD_PHASE_START) / (0.55 - THIRD_PHASE_START);
+				const s = THREE.MathUtils.lerp(1.0, 0.7, smooth01(t));
+				triangleGroupRef.current.scale.set(s, s, s);
+			} else if (scrollProgress < RETURN_SCROLL_START) {
+				triangleGroupRef.current.scale.set(0.7, 0.7, 0.7);
+			} else if (scrollProgress <= RETURN_SCROLL_END) {
+				const tUp = sstep(
+					scrollProgress,
+					RETURN_SCROLL_START,
+					RETURN_SCROLL_END,
+				);
+				const s = THREE.MathUtils.lerp(0.7, 1.0, smooth01(tUp));
+				triangleGroupRef.current.scale.set(s, s, s);
+			} else {
+				triangleGroupRef.current.scale.set(1, 1, 1);
+			}
+		}
 
-    // ====== 参照コード準拠：カードの"中央停止 + 慣性"だけ ======
-    if (videoCardsRef.current) {
-      const phaseLin = THREE.MathUtils.clamp(
-        (scrollProgress - THIRD_PHASE_START) /
-          (THIRD_PHASE_END - THIRD_PHASE_START),
-        0,
-        1
-      );
-      const phaseEased = smooth01(phaseLin) ** VIDEO_EASE;
+		// ====== 参照コード準拠：カードの"中央停止 + 慣性"だけ ======
+		if (videoCardsRef.current) {
+			const phaseLin = THREE.MathUtils.clamp(
+				(scrollProgress - THIRD_PHASE_START) /
+					(THIRD_PHASE_END - THIRD_PHASE_START),
+				0,
+				1,
+			);
+			const phaseEased = smooth01(phaseLin) ** VIDEO_EASE;
 
-      if (scrollProgress >= VIDEO_START_PROGRESS) {
-        const thetaRaw = phaseEased * TAU * ROT_TURNS;
-        const thetaDwell = dwellWithOffset(
-          thetaRaw,
-          layout.slotStep,
-          CARD_DWELL_FRAC,
-          -(-Math.PI / 2) // centerOffset と一致
-        );
-        const kRot = 1 - Math.exp(-delta * VIDEO_ROT_INERTIA);
-        smoothedTheta.current += (thetaDwell - smoothedTheta.current) * kRot;
+			if (scrollProgress >= VIDEO_START_PROGRESS) {
+				const thetaRaw = phaseEased * TAU * ROT_TURNS;
+				const thetaDwell = dwellWithOffset(
+					thetaRaw,
+					layout.slotStep,
+					CARD_DWELL_FRAC,
+					-(-Math.PI / 2), // centerOffset と一致
+				);
+				const kRot = 1 - Math.exp(-delta * VIDEO_ROT_INERTIA);
+				smoothedTheta.current += (thetaDwell - smoothedTheta.current) * kRot;
 
-        videoCardsRef.current.rotation.y = smoothedTheta.current;
-        videoCardsRef.current.visible = true;
+				videoCardsRef.current.rotation.y = smoothedTheta.current;
+				videoCardsRef.current.visible = true;
 
-        // マテリアルの深度状態を正規化
-        videoCardsRef.current.traverse((obj) => {
-          const m = (obj as THREE.Mesh)?.material as
-            | THREE.Material
-            | THREE.Material[]
-            | undefined;
-          if (!m) return;
-          const arr = Array.isArray(m) ? m : [m];
-          for (const mat of arr) {
-            (mat as any).depthTest = true;
-            (mat as any).depthWrite = true;
-            if ("alphaTest" in mat) (mat as any).alphaTest = 0.001;
-          }
-        });
-      } else {
-        videoCardsRef.current.visible = false;
-      }
-    }
+				// マテリアルの深度状態を正規化
+				videoCardsRef.current.traverse((obj) => {
+					const m = (obj as THREE.Mesh)?.material as
+						| THREE.Material
+						| THREE.Material[]
+						| undefined;
+					if (!m) return;
+					const arr = Array.isArray(m) ? m : [m];
+					for (const mat of arr) {
+						(mat as any).depthTest = true;
+						(mat as any).depthWrite = true;
+						if ("alphaTest" in mat) (mat as any).alphaTest = 0.001;
+					}
+				});
+			} else {
+				videoCardsRef.current.visible = false;
+			}
+		}
 
-    // ===== 黒円（拡大はゆっくり、縮小は速く） =====
-    if (circleRef.current) {
-      const endClamped = Math.max(
-        CIRCLE_SCROLL_START + 1e-6,
-        Math.min(CIRCLE_SCROLL_END, 1.0)
-      );
-      const tTarget = sstep(scrollProgress, CIRCLE_SCROLL_START, endClamped);
-      const speed =
-        tTarget >= circleTRef.current
-          ? CIRCLE_SMOOTH_EXPAND
-          : CIRCLE_SMOOTH_SHRINK;
-      const k = 1 - Math.exp(-delta * speed);
-      circleTRef.current += (tTarget - circleTRef.current) * k;
-      const growT = smooth01(circleTRef.current) ** CIRCLE_EASE;
+		// ===== 黒円（拡大はゆっくり、縮小は速く） =====
+		if (circleRef.current) {
+			const endClamped = Math.max(
+				CIRCLE_SCROLL_START + 1e-6,
+				Math.min(CIRCLE_SCROLL_END, 1.0),
+			);
+			const tTarget = sstep(scrollProgress, CIRCLE_SCROLL_START, endClamped);
+			const speed =
+				tTarget >= circleTRef.current
+					? CIRCLE_SMOOTH_EXPAND
+					: CIRCLE_SMOOTH_SHRINK;
+			const k = 1 - Math.exp(-delta * speed);
+			circleTRef.current += (tTarget - circleTRef.current) * k;
+			const growT = smooth01(circleTRef.current) ** CIRCLE_EASE;
 
-      if (growT > 0) {
-        if (triangleGroupRef.current) {
-          circleRef.current.position
-            .copy(triangleGroupRef.current.position)
-            .add(new THREE.Vector3(0, 0, 0.15));
-        }
+			if (growT > 0) {
+				if (triangleGroupRef.current) {
+					circleRef.current.position
+						.copy(triangleGroupRef.current.position)
+						.add(new THREE.Vector3(0, 0, 0.15));
+				}
 
-        const cam = state.camera as THREE.PerspectiveCamera;
-        const dist = cam.position.z - circleRef.current.position.z;
-        const halfH = Math.tan(THREE.MathUtils.degToRad(cam.fov * 0.5)) * dist;
-        const halfW = halfH * (state.size.width / state.size.height);
-        const needRadius = Math.sqrt(halfW * halfW + halfH * halfH);
-        const s = THREE.MathUtils.lerp(0.001, needRadius * 1.2, growT);
-        circleRef.current.scale.set(s, s, 1);
-        circleRef.current.visible = true;
+				const cam = state.camera as THREE.PerspectiveCamera;
+				const dist = cam.position.z - circleRef.current.position.z;
+				const halfH = Math.tan(THREE.MathUtils.degToRad(cam.fov * 0.5)) * dist;
+				const halfW = halfH * (state.size.width / state.size.height);
+				const needRadius = Math.sqrt(halfW * halfW + halfH * halfH);
+				const s = THREE.MathUtils.lerp(0.001, needRadius * 1.2, growT);
+				circleRef.current.scale.set(s, s, 1);
+				circleRef.current.visible = true;
 
-        const hideTri = s >= HIDE_TRI_AT_RADIUS;
-        if (triangleVisibleMeshRef.current)
-          triangleVisibleMeshRef.current.visible = !hideTri;
-        if (lineSegmentsRef.current) lineSegmentsRef.current.visible = !hideTri;
-        if (videoCardsRef.current) videoCardsRef.current.visible = !hideTri;
+				const hideTri = s >= HIDE_TRI_AT_RADIUS;
+				if (triangleVisibleMeshRef.current)
+					triangleVisibleMeshRef.current.visible = !hideTri;
+				if (lineSegmentsRef.current) lineSegmentsRef.current.visible = !hideTri;
+				if (videoCardsRef.current) videoCardsRef.current.visible = !hideTri;
 
-        if (starGroupRef.current)
-          starGroupRef.current.visible = growT < HIDE_BG_AT_T;
-      } else {
-        circleRef.current.visible = false;
-        circleRef.current.scale.set(0.001, 0.001, 1);
+				if (starGroupRef.current)
+					starGroupRef.current.visible = growT < HIDE_BG_AT_T;
+			} else {
+				circleRef.current.visible = false;
+				circleRef.current.scale.set(0.001, 0.001, 1);
 
-        if (triangleVisibleMeshRef.current)
-          triangleVisibleMeshRef.current.visible = true;
-        if (lineSegmentsRef.current) lineSegmentsRef.current.visible = true;
-        if (starGroupRef.current) starGroupRef.current.visible = true;
-      }
-    }
+				if (triangleVisibleMeshRef.current)
+					triangleVisibleMeshRef.current.visible = true;
+				if (lineSegmentsRef.current) lineSegmentsRef.current.visible = true;
+				if (starGroupRef.current) starGroupRef.current.visible = true;
+			}
+		}
 
-    // 背景スター微回転
-    if (starGroupRef.current) {
-      starGroupRef.current.rotation.y += 0.0005;
-    }
-  });
+		// 背景スター微回転
+		if (starGroupRef.current) {
+			starGroupRef.current.rotation.y += 0.0005;
+		}
+	});
 
-  return (
-    <>
-      <color attach="background" args={["black"]} />
+	return (
+		<>
+			<color attach="background" args={["black"]} />
 
-      {/* ===== 通常シーン ===== */}
-      <group ref={rootRef} position={[0, 0, ROOT_Z_OFFSET]}>
-        <group ref={starGroupRef}>
-          <Suspense fallback={null}>
-            <StarParticles selfRotate={false} position={[0, 0, -10]} />
-            <ShootingStars interval={3500} duration={4000} />
-            {/* MilkyWayを左上と右下に配置 */}
-            <MilkyWay position={[-30, 25, -25]} renderOrder={5} scale={70} />
-            <MilkyWay position={[30, -85, -85]} renderOrder={5} scale={205} />
-          </Suspense>
-        </group>
+			{/* ===== 通常シーン ===== */}
+			<group ref={rootRef} position={[0, 0, ROOT_Z_OFFSET]}>
+				<group ref={starGroupRef}>
+					<Suspense fallback={null}>
+						<StarParticles selfRotate={false} position={[0, 0, -10]} />
+						<ShootingStars interval={3500} duration={4000} />
+						{/* MilkyWayを左上と右下に配置 */}
+						<MilkyWay position={[-30, 25, -25]} renderOrder={5} scale={70} />
+						<MilkyWay position={[30, -85, -85]} renderOrder={5} scale={205} />
+					</Suspense>
+				</group>
 
-        {/* テトラ */}
-        <group ref={triangleGroupRef} position={[0, 0, 0]}>
-          <mesh ref={triangleVisibleMeshRef} renderOrder={3}>
-            <tetrahedronGeometry args={[tetraRadius, 0]} />
-            <heroShaderMaterial ref={heroMatRef} transparent={false} />
-          </mesh>
-          <primitive
-            ref={lineSegmentsRef}
-            object={lineSegments}
-            renderOrder={4}
-          />
-        </group>
+				{/* テトラ */}
+				<group ref={triangleGroupRef} position={[0, 0, 0]}>
+					<mesh ref={triangleVisibleMeshRef} renderOrder={3}>
+						<tetrahedronGeometry args={[tetraRadius, 0]} />
+						<heroShaderMaterial ref={heroMatRef} transparent={false} />
+					</mesh>
+					<primitive
+						ref={lineSegmentsRef}
+						object={lineSegments}
+						renderOrder={4}
+					/>
+				</group>
 
-        {/* カード群 */}
-        <group ref={videoCardsRef} renderOrder={2} position={[0, 0, 0]}>
-          <Suspense fallback={null}>
-            <VideoCardsRenderer
-              scrollProgress={scrollProgress}
-              videoSlides={videoSlides}
-              layout={layout}
-              requiredTurns={requiredTurns}
-              ROT_TURNS={ROT_TURNS}
-              onCardClick={onCardClick}
-            />
-          </Suspense>
-        </group>
+				{/* カード群 */}
+				<group ref={videoCardsRef} renderOrder={2} position={[0, 0, 0]}>
+					<Suspense fallback={null}>
+						<VideoCardsRenderer
+							scrollProgress={scrollProgress}
+							videoSlides={videoSlides}
+							layout={layout}
+							requiredTurns={requiredTurns}
+							ROT_TURNS={ROT_TURNS}
+							onCardClick={onCardClick}
+						/>
+					</Suspense>
+				</group>
 
-        {/* 黒円（暗転） */}
-        <mesh
-          ref={circleRef}
-          position={[0, 0, 0.15]}
-          renderOrder={1000}
-          frustumCulled={false}
-          visible={false}
-        >
-          <circleGeometry args={[1, 128]} />
-          <primitive attach="material" object={featherMat} />
-        </mesh>
-      </group>
+				{/* 黒円（暗転） */}
+				<mesh
+					ref={circleRef}
+					position={[0, 0, 0.15]}
+					renderOrder={1000}
+					frustumCulled={false}
+					visible={false}
+				>
+					<circleGeometry args={[1, 128]} />
+					<primitive attach="material" object={featherMat} />
+				</mesh>
+			</group>
 
-      {/* ===== 画面の液体屈折（ヒーロー内のみ作用） ===== */}
-      <mesh
-        ref={fluidRef}
-        renderOrder={10000}
-        frustumCulled={false}
-        raycast={() => null}
-      >
-        <planeGeometry args={[2, 2, 1, 1]} />
-        <hoverFluidMaterial
-          ref={(m: any) => {
-            if (m) hoverMatRef.current = m;
-          }}
-          attach="material"
-          transparent={true}
-          depthTest={false}
-          depthWrite={false}
-          blending={THREE.NoBlending as any}
-          toneMapped={false}
-        />
-      </mesh>
-    </>
-  );
+			{/* ===== 画面の液体屈折（ヒーロー内のみ作用） ===== */}
+			<mesh
+				ref={fluidRef}
+				renderOrder={10000}
+				frustumCulled={false}
+				raycast={() => null}
+			>
+				<planeGeometry args={[2, 2, 1, 1]} />
+				<hoverFluidMaterial
+					ref={(m: any) => {
+						if (m) hoverMatRef.current = m;
+					}}
+					attach="material"
+					transparent={true}
+					depthTest={false}
+					depthWrite={false}
+					blending={THREE.NoBlending as any}
+					toneMapped={false}
+				/>
+			</mesh>
+		</>
+	);
 }
 
 // ===== HeroCanvas =====
 interface HeroCanvasProps {
-  children: ReactNode;
-  videoSlides?: VideoSlide[];
+	children: ReactNode;
+	videoSlides?: VideoSlide[];
 }
 
 const HeroCanvas = ({ children, videoSlides }: HeroCanvasProps) => {
-  // フォールバック機能付きで安全にvideoSlidesを取得
-  const safeVideoSlides = getSafeVideoSlides(videoSlides);
+	// フォールバック機能付きで安全にvideoSlidesを取得
+	const safeVideoSlides = getSafeVideoSlides(videoSlides);
 
-  const [scrollProgress, setScrollProgress] = useState(0);
-  const [selectedCard, setSelectedCard] = useState<{
-    slide: VideoSlide;
-    index: number;
-  } | null>(null);
+	const [scrollProgress, setScrollProgress] = useState(0);
+	const [selectedCard, setSelectedCard] = useState<{
+		slide: VideoSlide;
+		index: number;
+	} | null>(null);
 
-  const handleCardClick = (slide: VideoSlide, index: number) => {
-    setSelectedCard({ slide, index });
-  };
+	const handleCardClick = (slide: VideoSlide, index: number) => {
+		setSelectedCard({ slide, index });
+	};
 
-  const handleCloseModal = () => {
-    setSelectedCard(null);
-  };
+	const handleCloseModal = () => {
+		setSelectedCard(null);
+	};
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.scrollY;
-      const docHeight =
-        document.documentElement.scrollHeight - window.innerHeight;
-      const scrolled = docHeight > 0 ? scrollTop / docHeight : 0;
-      setScrollProgress(Math.min(Math.max(scrolled, 0), 1));
-    };
+	useEffect(() => {
+		const handleScroll = () => {
+			const scrollTop = window.scrollY;
+			const docHeight =
+				document.documentElement.scrollHeight - window.innerHeight;
+			const scrolled = docHeight > 0 ? scrollTop / docHeight : 0;
+			setScrollProgress(Math.min(Math.max(scrolled, 0), 1));
+		};
 
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		handleScroll();
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
 
-  return (
-    <>
-      <Canvas
-        camera={{ position: [0, 0, CAMERA_Z], fov: 75 }}
-        style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          width: "100vw",
-          height: "100vh",
-          zIndex: 0,
-          pointerEvents: "auto",
-        }}
-        gl={{ antialias: true, alpha: false }}
-      >
-        <HeroScene
-          scrollProgress={scrollProgress}
-          videoSlides={safeVideoSlides}
-          onCardClick={handleCardClick}
-        />
-      </Canvas>
+	return (
+		<>
+			<Canvas
+				camera={{ position: [0, 0, CAMERA_Z], fov: 75 }}
+				style={{
+					position: "fixed",
+					top: 0,
+					left: 0,
+					width: "100vw",
+					height: "100vh",
+					zIndex: 0,
+					pointerEvents: "auto",
+				}}
+				gl={{ antialias: true, alpha: false }}
+			>
+				<HeroScene
+					scrollProgress={scrollProgress}
+					videoSlides={safeVideoSlides}
+					onCardClick={handleCardClick}
+				/>
+			</Canvas>
 
-      <div
-        style={{
-          position: "relative",
-          zIndex: 10,
-          minHeight: "1000vh",
-          pointerEvents: "none",
-        }}
-      >
-        {children}
-      </div>
+			<div
+				style={{
+					position: "relative",
+					zIndex: 10,
+					minHeight: "1000vh",
+					pointerEvents: "none",
+				}}
+			>
+				{children}
+			</div>
 
-      {/* カード詳細モーダル */}
-      {selectedCard && (
-        <CardDetailModal
-          isOpen={!!selectedCard}
-          onClose={handleCloseModal}
-          slide={selectedCard.slide}
-          index={selectedCard.index}
-        />
-      )}
-    </>
-  );
+			{/* カード詳細モーダル */}
+			{selectedCard && (
+				<CardDetailModal
+					isOpen={!!selectedCard}
+					onClose={handleCloseModal}
+					slide={selectedCard.slide}
+					index={selectedCard.index}
+				/>
+			)}
+		</>
+	);
 };
 
 export default HeroCanvas;

--- a/src/components/three/hero-canvas.tsx
+++ b/src/components/three/hero-canvas.tsx
@@ -20,7 +20,7 @@ import { FeatherCircleMaterial } from "./materials";
 import { getSafeVideoSlides } from "../../data/fallback-content";
 import type { VideoSlide } from "../../types/content";
 import { CardDetailModal } from "../ui/card-detail-modal";
-import { HeroHoverPointer } from "./HeroHoverPointer";
+import { HtmlHoverPointer } from "./HtmlHoverPointer";
 
 // ===== 全体スケール =====
 const SCENE_SCALE = 1.2;
@@ -99,12 +99,14 @@ interface HeroSceneProps {
 	scrollProgress: number;
 	videoSlides: VideoSlide[];
 	onCardClick?: (slide: VideoSlide, index: number) => void;
+	onCardHover?: (isHovering: boolean) => void;
 }
 
 function HeroScene({
 	scrollProgress,
 	videoSlides,
 	onCardClick,
+	onCardHover,
 }: HeroSceneProps) {
 	const heroMatRef = useRef<any>(null);
 	const starGroupRef = useRef<THREE.Group>(null);
@@ -114,10 +116,6 @@ function HeroScene({
 	const circleRef = useRef<THREE.Mesh>(null);
 	const videoCardsRef = useRef<THREE.Group>(null);
 	const rootRef = useRef<THREE.Group>(null);
-
-	// hover ポインタ用の状態
-	const [isCardHovering, setIsCardHovering] = useState(false);
-	const mousePosition = useRef(new THREE.Vector2(0, 0));
 
 	// 黒円マテリアル
 	const featherMat = useMemo(() => {
@@ -151,11 +149,6 @@ function HeroScene({
 			mouseRaw.current.set(
 				e.clientX / window.innerWidth,
 				1 - e.clientY / window.innerHeight,
-			);
-			// ポインタ用のマウス位置（-1 ~ 1の範囲）
-			mousePosition.current.set(
-				(e.clientX / window.innerWidth) * 2 - 1,
-				-(e.clientY / window.innerHeight) * 2 + 1,
 			);
 			hoverStrength.current = 1;
 		};
@@ -509,7 +502,7 @@ function HeroScene({
 							requiredTurns={requiredTurns}
 							ROT_TURNS={ROT_TURNS}
 							onCardClick={onCardClick}
-							onCardHover={setIsCardHovering}
+							onCardHover={onCardHover}
 						/>
 					</Suspense>
 				</group>
@@ -526,12 +519,6 @@ function HeroScene({
 					<primitive attach="material" object={featherMat} />
 				</mesh>
 			</group>
-
-			{/* ===== Hover Pointer（流体エフェクトの手前） ===== */}
-			<HeroHoverPointer
-				isHovering={isCardHovering}
-				mousePosition={mousePosition.current}
-			/>
 
 			{/* ===== 画面の液体屈折（ヒーロー内のみ作用） ===== */}
 			<mesh
@@ -572,6 +559,7 @@ const HeroCanvas = ({ children, videoSlides }: HeroCanvasProps) => {
 		slide: VideoSlide;
 		index: number;
 	} | null>(null);
+	const [isCardHovering, setIsCardHovering] = useState(false);
 
 	const handleCardClick = (slide: VideoSlide, index: number) => {
 		setSelectedCard({ slide, index });
@@ -614,6 +602,7 @@ const HeroCanvas = ({ children, videoSlides }: HeroCanvasProps) => {
 					scrollProgress={scrollProgress}
 					videoSlides={safeVideoSlides}
 					onCardClick={handleCardClick}
+					onCardHover={setIsCardHovering}
 				/>
 			</Canvas>
 
@@ -637,6 +626,9 @@ const HeroCanvas = ({ children, videoSlides }: HeroCanvasProps) => {
 					index={selectedCard.index}
 				/>
 			)}
+
+			{/* HTMLホバーポインタ */}
+			<HtmlHoverPointer isHovering={isCardHovering} />
 		</>
 	);
 };

--- a/src/components/three/hero-canvas.tsx
+++ b/src/components/three/hero-canvas.tsx
@@ -20,6 +20,7 @@ import { FeatherCircleMaterial } from "./materials";
 import { getSafeVideoSlides } from "../../data/fallback-content";
 import type { VideoSlide } from "../../types/content";
 import { CardDetailModal } from "../ui/card-detail-modal";
+import { HeroHoverPointer } from "./HeroHoverPointer";
 
 // ===== 全体スケール =====
 const SCENE_SCALE = 1.2;
@@ -114,6 +115,10 @@ function HeroScene({
 	const videoCardsRef = useRef<THREE.Group>(null);
 	const rootRef = useRef<THREE.Group>(null);
 
+	// hover ポインタ用の状態
+	const [isCardHovering, setIsCardHovering] = useState(false);
+	const mousePosition = useRef(new THREE.Vector2(0, 0));
+
 	// 黒円マテリアル
 	const featherMat = useMemo(() => {
 		const m = new (FeatherCircleMaterial as any)();
@@ -146,6 +151,11 @@ function HeroScene({
 			mouseRaw.current.set(
 				e.clientX / window.innerWidth,
 				1 - e.clientY / window.innerHeight,
+			);
+			// ポインタ用のマウス位置（-1 ~ 1の範囲）
+			mousePosition.current.set(
+				(e.clientX / window.innerWidth) * 2 - 1,
+				-(e.clientY / window.innerHeight) * 2 + 1,
 			);
 			hoverStrength.current = 1;
 		};
@@ -499,6 +509,7 @@ function HeroScene({
 							requiredTurns={requiredTurns}
 							ROT_TURNS={ROT_TURNS}
 							onCardClick={onCardClick}
+							onCardHover={setIsCardHovering}
 						/>
 					</Suspense>
 				</group>
@@ -515,6 +526,12 @@ function HeroScene({
 					<primitive attach="material" object={featherMat} />
 				</mesh>
 			</group>
+
+			{/* ===== Hover Pointer（流体エフェクトの手前） ===== */}
+			<HeroHoverPointer
+				isHovering={isCardHovering}
+				mousePosition={mousePosition.current}
+			/>
 
 			{/* ===== 画面の液体屈折（ヒーロー内のみ作用） ===== */}
 			<mesh

--- a/src/components/ui/hero-action-button.tsx
+++ b/src/components/ui/hero-action-button.tsx
@@ -26,7 +26,10 @@ export function HeroActionButton({
 	const hoverBgColor = variant === "primary" ? "bg-white/30" : "bg-white/20";
 
 	return (
-		<Link className={`${baseClasses} ${variantClasses} pointer-events-auto`} href={href}>
+		<Link
+			className={`${baseClasses} ${variantClasses} pointer-events-auto`}
+			href={href}
+		>
 			{/* スライドイン背景 */}
 			<div
 				className={`absolute inset-0 ${hoverBgColor} -translate-x-full group-hover:translate-x-0 transition-transform duration-500 ease-out`}


### PR DESCRIPTION
## Summary
トップページの3Dカードにマウスhover時の円形ポインタエフェクトを実装しました。流体エフェクトの影響を受けないようHTMLレイヤーで実装し、カードの表示状態に応じた正確なhover管理を実現しています。

- HTMLレイヤーによる円形ポインタの実装（流体エフェクト干渉回避）
- drawOpacityベースの正確なhover状態管理
- カードのフェードイン/アウト時の自動hover状態リセット
- 円の中心に「click」テキストを表示

## 主な変更内容

### 新規作成ファイル
- `src/components/three/HtmlHoverPointer.tsx`
  - HTMLレイヤーで動作する円形ポインタコンポーネント
  - z-index: 9999で流体エフェクトの上に表示
  - マウス位置追従 + スムーズなスケールアニメーション

### 変更ファイル

**`src/components/three/VideoCard3D.tsx`**
- `onHoverChange` callbackプロパティを追加
- `isHoveringRef`でhover状態を追跡
- `drawOpacity > 0.5`の時のみhoverを有効化
- `useFrame`内でopacity低下時に自動的にhover状態をリセット

**`src/components/three/VideoCardsRenderer.tsx`**
- `onCardHover` callbackを各カードに伝播

**`src/components/three/hero-canvas.tsx`**
- `isCardHovering`状態を管理
- `HtmlHoverPointer`コンポーネントを統合
- カードからのhoverイベントを受け取り

## 技術的なポイント

1. **HTMLレイヤー実装の理由**
   - 当初Three.jsメッシュで実装したが、流体エフェクトの`blending: NoBlending`により非表示に
   - HTMLレイヤー（`position: fixed` + `z-index: 9999`）で実装することで解決

2. **正確なhover管理**
   - `opacity`ではなく実際の描画透明度`drawOpacity`を使用
   - カードのフェードアウト中も正確にhover状態を管理
   - `useFrame`内で毎フレームチェックし、`drawOpacity <= 0.5`で強制リセット

3. **UX配慮**
   - カードが50%以上表示されている時のみhover有効
   - 出現前のカード領域でポインタが表示されない
   - スムーズなアニメーション（lerp: 0.15）

## Test plan
- [ ] トップページでカードにマウスhoverすると円形ポインタが表示される
- [ ] 円の中心に「click」テキストが表示される
- [ ] カードのフェードイン前はポインタが表示されない
- [ ] カードのフェードアウト中は自動的にポインタが消える
- [ ] 流体エフェクトの上にポインタが表示される
- [ ] マウス移動に円がスムーズに追従する
- [ ] ビルドが成功する（`pnpm build`）
- [ ] Lintエラーがない（`pnpm lint`）
