### PR TITLE
fix: 宇宙飛行士の表示安定化 (シーンのクローン対応)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "three": "^0.165.0",
+    "three-stdlib": "^2.36.1",
     "zod": "^4.1.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       three:
         specifier: ^0.165.0
         version: 0.165.0
+      three-stdlib:
+        specifier: ^2.36.1
+        version: 2.36.1(three@0.165.0)
       zod:
         specifier: ^4.1.5
         version: 4.1.5
@@ -2083,8 +2086,8 @@ packages:
     peerDependencies:
       three: '>= 0.159.0'
 
-  three-stdlib@2.36.0:
-    resolution: {integrity: sha512-kv0Byb++AXztEGsULgMAs8U2jgUdz6HPpAB/wDJnLiLlaWQX2APHhiTJIN7rqW+Of0eRgcp7jn05U1BsCP3xBA==}
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
     peerDependencies:
       three: '>=0.128.0'
 
@@ -2867,7 +2870,7 @@ snapshots:
       suspend-react: 0.1.3(react@19.1.2)
       three: 0.165.0
       three-mesh-bvh: 0.8.3(three@0.165.0)
-      three-stdlib: 2.36.0(three@0.165.0)
+      three-stdlib: 2.36.1(three@0.165.0)
       troika-three-text: 0.52.4(three@0.165.0)
       tunnel-rat: 0.1.2(@types/react@19.1.9)(react@19.1.2)
       use-sync-external-store: 1.5.0(react@19.1.2)
@@ -4130,7 +4133,7 @@ snapshots:
     dependencies:
       three: 0.165.0
 
-  three-stdlib@2.36.0(three@0.165.0):
+  three-stdlib@2.36.1(three@0.165.0):
     dependencies:
       '@types/draco3d': 1.4.10
       '@types/offscreencanvas': 2019.7.3

--- a/src/components/three/Astronaut.tsx
+++ b/src/components/three/Astronaut.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useRef, useEffect } from "react";
-import { useFrame } from "@react-three/fiber";
+import { useRef, useEffect, useMemo } from "react";
+import { useFrame, useGraph } from "@react-three/fiber";
 import { useGLTF, useAnimations } from "@react-three/drei";
 import * as THREE from "three";
+import { SkeletonUtils } from "three-stdlib";
 
 interface AstronautProps {
     position?: [number, number, number];
@@ -16,6 +17,12 @@ export function Astronaut({ position = [0, 0, 0], scale = 2, isMobile = false }:
 	const { scene, animations } = useGLTF(
 		"https://mb9hgkfxcmjgkuip.public.blob.vercel-storage.com/artro_perfect.glb",
 	);
+
+    // シーンをクローンして、各インスタンスが独立したモデルを持つようにする
+    const clone = useMemo(() => SkeletonUtils.clone(scene), [scene]);
+    // クローンされたシーンのグラフを取得（必要であれば）
+    const { nodes } = useGraph(clone);
+
 	const { actions, names } = useAnimations(animations, groupRef);
 
 	// アニメーションを再生
@@ -32,8 +39,8 @@ export function Astronaut({ position = [0, 0, 0], scale = 2, isMobile = false }:
 			});
 		}
 
-		// マテリアル設定
-		scene.traverse((child) => {
+		// マテリアル設定（クローンに対して行う）
+		clone.traverse((child: THREE.Object3D) => {
 			if ((child as THREE.Mesh).isMesh) {
 				const mesh = child as THREE.Mesh;
 				if (mesh.material) {
@@ -44,7 +51,7 @@ export function Astronaut({ position = [0, 0, 0], scale = 2, isMobile = false }:
 				}
 			}
 		});
-	}, [actions, names, animations, scene]);
+	}, [actions, names, animations, clone]);
 
 	useFrame((state) => {
 		if (groupRef.current) {
@@ -72,7 +79,7 @@ export function Astronaut({ position = [0, 0, 0], scale = 2, isMobile = false }:
 
 	return (
 		<group ref={groupRef}>
-			<primitive object={scene} scale={scale} />
+			<primitive object={clone} scale={scale} />
 		</group>
 	);
 }


### PR DESCRIPTION
## 主な変更点
### 1. ハンバーガーメニュー (`SidebarMenu.tsx`)
- **表記変更**:
  - MISSION → 「目指すもの」
  - ABOUT → 「TANEBI CREATIVEについて」
- **デザイン調整**:
  - ホバー時の白背景カード（影・拡大部分）を削除し、シンプルにしました。
  - ホバー時のテキスト色を `#60d5fa` (Light Blue) に変更し、視認性を統一。
  - メニュー背景（リキッド演出）の色を `#1f1f1f` (Dark Gray) に変更し、全体のトーンを引き締めました。
### 2. Missionセクション ([MissionSection.tsx](cci:7://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/app/components/MissionSection.tsx:0:0-0:0), `MissionContent.tsx`)
- **モバイルレイアウト**:
  - コンテンツ全体の横幅パディングを削除し、モバイルで画面幅いっぱいに表示できるように調整。
  - 内部ラッパーに `px-2` を付与し、最小限の余白を確保。
- **タイポグラフィ**:
  - モバイル時のタイトルフォントサイズを `1.6rem` に調整しました。
### 3. Loading画面 ([LoadingScreen.tsx](cci:7://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/loading/LoadingScreen.tsx:0:0-0:0))
- **レイアウト**:
  - テキストコンテナに `px-4` を追加し、モバイルでの表示崩れ（幅超過）を防止。
- **タイポグラフィ**:
  - 「TANEBI CREATIVE」: トップページのデザインと完全に一致させました（`text-2xl md:text-3xl font-bold`）。
  - 「LOADING」: サイズを `text-xl md:text-2xl` に縮小し、屋号（TANEBI CREATIVE）の方が相対的に大きく見えるよう調整しました。
### 4. 宇宙飛行士・3Dコンテンツ ([Astronaut.tsx](cci:7://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/three/Astronaut.tsx:0:0-0:0), [hero-canvas.tsx](cci:7://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/three/hero-canvas.tsx:0:0-0:0), [LoadingScene.tsx](cci:7://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/loading/LoadingScene.tsx:0:0-0:0))
- **コンポーネント化と安定化**:
  - [LoadingScene](cci:1://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/loading/LoadingScene.tsx:33:0-60:1) 内の宇宙飛行士ロジックを [Astronaut.tsx](cci:7://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/three/Astronaut.tsx:0:0-0:0) に切り出し、再利用可能にしました。
  - **重要な修正**: `SkeletonUtils.clone()` を導入し、GLTFシーンをクローンして使用するように変更。これにより、Loading画面とトップページで3Dモデルの所有権が競合し、表示が消える問題を解決しました。
- **トップページ・宇宙エリアへの統合**:
  - [HeroCanvas](cci:1://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/three/hero-canvas.tsx:718:0-808:2) に [Astronaut](cci:1://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/three/Astronaut.tsx:14:0-84:1) を追加し、トップページ背景およびAboutセクション後の宇宙エリアで表示されるようにしました。
  - [HeroScene](cci:1://file:///Users/sugawarahayato/portfolit-site2/corporate-app/src/components/three/hero-canvas.tsx:110:0-710:1) に照明（`ambientLight`, `directionalLight`）を追加し、モデルが黒いシルエットにならず、正しくライティングされるよう修正しました。
- **モバイル最適化**:
  - モバイル表示時、宇宙飛行士の移動範囲を大幅に縮小 (`x: 2.2`, `y: 1.5`) し、画面外への見切れを防ぎました。
  - スケールも `1.3` に縮小調整しています（デスクトップは `2.0`）。
## 確認事項
- [ ] ハンバーガーメニューのホバー色（`#60d5fa`）と背景色
- [ ] スマホでのLoading画面のデザイン（パディング、フォントサイズ比率）
- [ ] Loading → トップページ遷移時に、宇宙飛行士が消えずに両方で表示されること
- [ ] トップページおよびAbout後のエリアで、宇宙飛行士が明るく表示されること
- [ ] スマホで宇宙飛行士が画面中央付近に留まっていること