### PR TITLE
ci: ダミーCIを実際のlint・buildチェックに修正

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,41 @@
-name: Lint with Biome
+name: CI
+
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
+
 jobs:
-  lint:
+  lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Always succeed
-        run: echo "Final attempt to register the check."
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (Biome)
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+        env:
+          MICROCMS_SERVICE_DOMAIN: ${{ secrets.MICROCMS_SERVICE_DOMAIN }}
+          MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
+          MICROCMS_BLOG_API_ID: ${{ secrets.MICROCMS_BLOG_API_ID }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          CONTACT_EMAIL: ${{ secrets.CONTACT_EMAIL }}
+          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}


### PR DESCRIPTION
## 概要
`echo` のみのダミーワークフローを、実際に lint・build を実行する CI に置き換えた。

## 変更内容
- `pnpm install --frozen-lockfile` → `pnpm lint`（Biome）→ `pnpm build` の順で実行
- トリガーを `dev` と `main` へのPRに設定
- ビルドに必要な環境変数を GitHub Secrets から注入

## 注意
**このPRのCI自体は通りません**（このPRのCIを通すには Secrets の設定が必要）。
マージ後、GitHub リポジトリの Settings → Secrets and variables → Actions に以下を登録してください：

| Secret名 | 内容 |
|---------|------|
| `MICROCMS_SERVICE_DOMAIN` | microCMS サービスドメイン |
| `MICROCMS_API_KEY` | microCMS API キー |
| `MICROCMS_BLOG_API_ID` | microCMS ブログ API ID |
| `DATABASE_URL` | Supabase 接続 URL |
| `DIRECT_URL` | Supabase Direct URL |
| `RESEND_API_KEY` | Resend API キー |
| `CONTACT_EMAIL` | お問い合わせ送信先メールアドレス |
| `NEXT_PUBLIC_SITE_URL` | サイト URL（例: https://tanebi-net.com） |