### PR TITLE
perf: パフォーマンス追加改善（3D初期化遅延・チャンク分割・フォント削除）

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,11 +39,37 @@ const nextConfig: NextConfig = {
 		],
 	},
 	// ここから追加
-	webpack(config) {
+	webpack(config, { isServer }) {
 		config.module.rules.push({
 			test: /\.glsl$/,
 			loader: "raw-loader",
 		});
+
+		// クライアントビルドでThree.js関連を独立チャンクに分離し、初期バンドルを軽量化
+		if (!isServer) {
+			const cacheGroups =
+				config.optimization?.splitChunks?.cacheGroups || {};
+			cacheGroups.three = {
+				test: /[\\/]node_modules[\\/](three|@react-three|three-stdlib)[\\/]/,
+				name: "three-vendor",
+				chunks: "all" as const,
+				priority: 30,
+			};
+			cacheGroups.framerMotion = {
+				test: /[\\/]node_modules[\\/]framer-motion[\\/]/,
+				name: "framer-motion-vendor",
+				chunks: "all" as const,
+				priority: 20,
+			};
+			config.optimization = {
+				...config.optimization,
+				splitChunks: {
+					...config.optimization?.splitChunks,
+					cacheGroups,
+				},
+			};
+		}
+
 		return config;
 	},
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,8 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import { DEFAULT_METADATA } from "@/lib/seo";
 import { ThemeProvider } from "@/contexts/theme-context";
 import Providers from "@/components/Providers";
 import "./globals.css";
-
-const geistSans = Geist({
-	variable: "--font-geist-sans",
-	subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-	variable: "--font-geist-mono",
-	subsets: ["latin"],
-});
 
 export const metadata: Metadata = DEFAULT_METADATA;
 
@@ -24,10 +13,7 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="ja" suppressHydrationWarning>
-			<body
-				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-				suppressHydrationWarning
-			>
+			<body className="antialiased" suppressHydrationWarning>
 				<Providers>
 					<ThemeProvider>{children}</ThemeProvider>
 				</Providers>

--- a/src/components/three/HeroCanvasWrapper.tsx
+++ b/src/components/three/HeroCanvasWrapper.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { useHeroState } from "../../contexts/HeroStateContext";
 import type { VideoSlide } from "../../types/content";
@@ -10,15 +11,27 @@ const HeroCanvas = dynamic(() => import("./hero-canvas"), {
 });
 
 interface HeroCanvasWrapperProps {
-	// children removed from here as they are now rendered by HeroCanvasWithCMS
 	videoSlides?: VideoSlide[];
 }
 
 export default function HeroCanvasWrapper({
 	videoSlides,
 }: HeroCanvasWrapperProps) {
-	// Get state from the Provider (which must be higher up in the tree)
 	const heroState = useHeroState();
+	const [ready, setReady] = useState(false);
+
+	// 初期ロード（LoadingScreen等）が落ち着いてからCanvasをマウント
+	// これによりThree.js初期化がメインスレッドの初期処理と競合しなくなり、TBTが改善
+	useEffect(() => {
+		if ("requestIdleCallback" in window) {
+			const id = window.requestIdleCallback(() => setReady(true));
+			return () => window.cancelIdleCallback(id);
+		}
+		const timer = setTimeout(() => setReady(true), 100);
+		return () => clearTimeout(timer);
+	}, []);
+
+	if (!ready) return null;
 
 	return <HeroCanvas videoSlides={videoSlides} heroState={heroState} />;
 }


### PR DESCRIPTION
## 概要
パフォーマンス追加改善をmainにリリース。3D初期化の遅延、webpackチャンク分割、未使用フォント削除により、Lighthouseスコア69点を達成。

## 変更内容
- HeroCanvasWrapperでrequestIdleCallback待機し、初期ロード中の3D初期化を遅延（TBT改善）
- webpack splitChunksでThree.js(766KB)・framer-motion(41KB)を独立チャンクに分離
- main-app.jsが7.0MB→最大766KBに分割され、初期JSパース量を大幅削減
- 未使用のGeist/Geist_Monoフォントを削除

## Lighthouse計測結果（ローカル pnpm build + start）
| 指標 | スコア |
|------|--------|
| Performance | 69 |
| Accessibility | 100 |
| Best Practices | 78 |
| SEO | 91 |

## 動作確認
- ローカルでLighthouse計測済み
- 3Dシーン見た目変更なし

## 関連
- PR #139, #141, #142, #143