### PR TITLE
feat: Google Tag Manager導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.2.1",
+		"@next/third-parties": "^16.2.6",
 		"@radix-ui/react-checkbox": "^1.3.3",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-label": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.7))
+      '@next/third-parties':
+        specifier: ^16.2.6
+        version: 16.2.6(next@15.5.16(@playwright/test@1.54.2)(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(react@19.1.7)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
@@ -431,6 +434,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.2.6':
+    resolution: {integrity: sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1956,6 +1965,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   three-mesh-bvh@0.8.3:
     resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
     peerDependencies:
@@ -2391,6 +2403,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.16':
     optional: true
+
+  '@next/third-parties@16.2.6(next@15.5.16(@playwright/test@1.54.2)(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(react@19.1.7)':
+    dependencies:
+      next: 15.5.16(@playwright/test@1.54.2)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
+      react: 19.1.7
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3881,6 +3899,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   three-mesh-bvh@0.8.3(three@0.165.0):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { DEFAULT_METADATA } from "@/lib/seo";
 import { ThemeProvider } from "@/contexts/theme-context";
 import Providers from "@/components/Providers";
+import { GTMScript } from "@/components/GTMScript";
 import "./globals.css";
 
 export const metadata: Metadata = DEFAULT_METADATA;
@@ -14,6 +15,7 @@ export default function RootLayout({
 	return (
 		<html lang="ja" suppressHydrationWarning>
 			<body className="antialiased" suppressHydrationWarning>
+				<GTMScript />
 				<Providers>
 					<ThemeProvider>{children}</ThemeProvider>
 				</Providers>

--- a/src/components/GTMScript.tsx
+++ b/src/components/GTMScript.tsx
@@ -1,0 +1,8 @@
+import { GoogleTagManager } from "@next/third-parties/google";
+
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
+
+export function GTMScript() {
+	if (!GTM_ID) return null;
+	return <GoogleTagManager gtmId={GTM_ID} />;
+}


### PR DESCRIPTION
## 概要

GTMをNext.js App Routerに組み込み、発火確認済み。

- Vercelプレビュー環境でGTMプレビューモードによる発火確認済み
- `@next/third-parties/google` 使用（Biomeセキュリティルール準拠）
- `NEXT_PUBLIC_GTM_ID` 未設定時は何もレンダリングしない安全な実装

## 関連PR

- #150 (feature/add-gtm → dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)