### PR TITLE
fix: JSON-LD・seo.ts・llms.txtの文言をサイト本体と一致させる

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ export default function Home() {
 								url: "https://tanebi-net.com",
 								image: "https://tanebi-net.com/images/ogp.jpg",
 								description:
-									"岩手県奥州市を拠点に、AIを活用した業務改善やDX推進、ホームページ・ECサイト制作、アプリ開発を行っています。地域の中小企業がデジタルを実務で活かせるよう支援します。",
+									"岩手県奥州市を拠点に、AIを活用した業務改善やDX推進、Webサイト・ECサイト制作、アプリ開発を行っています。地域の中小企業がデジタルを実務で活かせるよう支援します。",
 								slogan:
 									"種から形へ、種火を力に。技術と対話で、事業の前進を支援します。",
 								address: {
@@ -43,10 +43,10 @@ export default function Home() {
 									"AI事業者",
 									"AI導入支援",
 									"AI活用コンサルティング",
-									"SEO（AIO・LLMO を含む生成AI時代の検索最適化）",
+									"SEO（AIO/LLMO を含む生成AI時代の検索最適化）",
 									"構造化データ・コンテンツ設計",
 									"岩手県内の中小企業向けDX・業務効率化支援",
-									"AIを活用した集客・ホームページ制作",
+									"AIを活用した集客・Webサイト制作",
 									"AIによる事務作業の自動化",
 									"社内情報の整理・ナレッジ共有の仕組み作り",
 								],
@@ -82,7 +82,7 @@ export default function Home() {
 							{
 								"@type": "Service",
 								"@id": "https://tanebi-net.com/#service-dx",
-								name: "AI業務効率化・DX支援（LLMO 対応）",
+								name: "AI実務活用・DX支援・SEO対応",
 								provider: {
 									"@id": "https://tanebi-net.com/#organization",
 								},

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const SITE_CONFIG = {
 	name: "TANEBI CREATIVE | 岩手・奥州のWeb開発・AI活用・DX支援",
 	description:
-		"岩手県奥州市を拠点に、AIを活用した業務改善やDX推進、ホームページ・ECサイト制作、アプリ開発を行っています。地域の中小企業がデジタルを実務で活かせるよう支援します。",
+		"岩手県奥州市を拠点に、AIを活用した業務改善やDX推進、Webサイト・ECサイト制作、アプリ開発を行っています。地域の中小企業がデジタルを実務で活かせるよう支援します。",
 	url: process.env.NEXT_PUBLIC_SITE_URL || "https://tanebi-net.com",
 	author: "TANEBI CREATIVE",
 	twitterHandle: "@tanebi_creative", // Replace with actual handle


### PR DESCRIPTION
## Summary

前PR (#152, #153) でヒーロー文言・ミッション文言を更新した際、JSON-LD・`seo.ts`・`public/llms.txt`への反映が漏れていた箇所を網羅的に修正。

### JSON-LD (`src/app/page.tsx`) / メタ情報 (`src/lib/seo.ts`)

- **Organization.description / SITE_CONFIG.description**: 「ホームページ・ECサイト制作」→「Webサイト・ECサイト制作」
- **knowsAbout**: 「ホームページ制作」→「Webサイト制作」、AIO/LLMO の区切り文字を中点（・）からスラッシュ（/）に統一
- **Service 2 name**: 「AI業務効率化・DX支援（LLMO 対応）」→「AI実務活用・DX支援・SEO対応」（SEO主軸・LLMO は description に残す）

### LLMクローラー向け情報 (`public/llms.txt`)

- ホームページ・ECサイト制作 → Webサイト・ECサイト制作
- AI業務効率化 → AI実務活用
- アプリ制作 → アプリ開発
- ホームページ制作（AIO対応） → Webサイト制作（SEO/AIO 対応）
- ミッション01 タイトル・説明を MissionContent 最新版に同期
- ミッション03 説明を MissionContent 最新版（セキュリティ視点）に同期
- キャッチコピー「時代はSEOからAIOへ」を削除（HomeClient から削除済みのため）

> `seo.ts` の keywords 内「ホームページ制作 岩手」は検索キーワードのため変更しない。

## Test plan

- [x] DevTools で `application/ld+json` を確認（Organization.description / Service name が最新表現になっていること）
- [x] `/llms.txt` を直接開いて内容が最新サイト文言と一致していること
- [x] Google Rich Results Test でエラーがないこと
- [x] grep で旧表現が残っていないこと確認: `ホームページ` / `アプリ制作` / `AI業務効率化` / `時代はSEOからAIOへ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)