### PR TITLE
feat: microCMS Draft Mode プレビュー機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ public/images/mock/
 # 大きな3Dモデルファイル（Vercel Blobで管理）
 # public/models/*.glb
 public/models/*.fbx
+
+# ブログ記事の下書き（microCMS公開前のローカル原稿）
+/blog/
+
+# ローカル作業メモ・進捗管理（git管理外）
+/doc/

--- a/src/app/api/exit-preview/route.ts
+++ b/src/app/api/exit-preview/route.ts
@@ -1,0 +1,22 @@
+import { cookies, draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+
+const SLUG_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export async function GET(request: NextRequest) {
+	const { searchParams } = request.nextUrl;
+	const slug = searchParams.get("slug");
+
+	if (slug && !SLUG_PATTERN.test(slug)) {
+		return new Response("Invalid slug", { status: 400 });
+	}
+
+	const dm = await draftMode();
+	dm.disable();
+
+	const cookieStore = await cookies();
+	cookieStore.delete("__microcms_preview_draftkey");
+
+	redirect(slug ? `/blog/${encodeURIComponent(slug)}` : "/blog");
+}

--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -1,0 +1,49 @@
+import { cookies, draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+import { getBlogPost } from "@/lib/microcms";
+
+const SLUG_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export async function GET(request: NextRequest) {
+	const secret = process.env.MICROCMS_PREVIEW_SECRET;
+	if (!secret) {
+		console.error("[preview] MICROCMS_PREVIEW_SECRET が未設定です");
+		return new Response("Preview not configured", { status: 500 });
+	}
+
+	const { searchParams } = request.nextUrl;
+	const requestSecret = searchParams.get("secret");
+	const slug = searchParams.get("slug");
+	const draftKey = searchParams.get("draftKey");
+
+	if (!requestSecret || requestSecret !== secret) {
+		return new Response("Invalid token", { status: 401 });
+	}
+	if (!slug || !SLUG_PATTERN.test(slug)) {
+		return new Response("Invalid slug", { status: 400 });
+	}
+	if (!draftKey) {
+		return new Response("Missing draftKey", { status: 400 });
+	}
+
+	try {
+		await getBlogPost(slug, draftKey);
+	} catch {
+		return new Response("Post not found", { status: 404 });
+	}
+
+	const dm = await draftMode();
+	dm.enable();
+
+	const cookieStore = await cookies();
+	cookieStore.set("__microcms_preview_draftkey", draftKey, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		sameSite: "lax",
+		maxAge: 3600,
+		path: "/blog",
+	});
+
+	redirect(`/blog/${encodeURIComponent(slug)}`);
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { cookies, draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { TableOfContentsClient } from "@/components/blog/post-toc-client";
@@ -39,13 +40,20 @@ export async function generateMetadata({
 
 export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 	const { slug } = await params;
+	const { isEnabled } = await draftMode();
+
+	let draftKey: string | undefined;
+	if (isEnabled) {
+		const cookieStore = await cookies();
+		draftKey = cookieStore.get("__microcms_preview_draftkey")?.value;
+	}
 
 	let post: BlogPost | null = null;
 	let profile: AuthorProfile | null = null;
 
 	try {
 		[post, profile] = await Promise.all([
-			getBlogPost(slug),
+			getBlogPost(slug, draftKey),
 			getAuthorProfile().catch((err) => {
 				console.warn("プロフィール取得エラー:", err);
 				return null;
@@ -101,6 +109,15 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 	);
 
 	return (
+		<>
+		{isEnabled && (
+			<div className="fixed top-0 left-0 right-0 z-50 bg-yellow-400 text-yellow-900 text-center text-sm py-1 font-medium">
+				プレビューモード —{" "}
+				<a href={`/api/exit-preview?slug=${slug}`} className="underline">
+					終了する
+				</a>
+			</div>
+		)}
 		<div className="container mx-auto px-4 pt-16 lg:pt-8 py-8 max-w-5xl">
 			{/* ヘッダー部分（常に1カラム） */}
 			<nav className="mb-8 hidden lg:block">
@@ -170,16 +187,18 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 
 			<ScrollToTop />
 		</div>
+		</>
 	);
 }
 
 // 静的生成のためのパス生成
 export async function generateStaticParams() {
-	// ビルド時に環境変数が設定されていない場合は空配列を返す
-	if (!process.env.MICROCMS_SERVICE_DOMAIN || !process.env.MICROCMS_API_KEY) {
-		console.warn(
-			"microCMS環境変数が設定されていません。静的パス生成をスキップします。",
-		);
+	// モックモードまたはビルド時に環境変数が設定されていない場合はスキップ
+	if (
+		process.env.USE_MOCK_BLOG === "true" ||
+		!process.env.MICROCMS_SERVICE_DOMAIN ||
+		!process.env.MICROCMS_API_KEY
+	) {
 		return [];
 	}
 

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -113,7 +113,7 @@ export const getBlogPosts = async (
 };
 
 // 特定のブログ記事を取得
-export const getBlogPost = async (id: string): Promise<BlogPost> => {
+export const getBlogPost = async (id: string, draftKey?: string): Promise<BlogPost> => {
 	if (useMock) {
 		const post = getMockBlogPost(id);
 		if (!post) throw new Error(`Mock post not found: ${id}`);
@@ -130,7 +130,8 @@ export const getBlogPost = async (id: string): Promise<BlogPost> => {
 		queries: {
 			fields:
 				"id,title,content,eyecatch,category,mediaType,videoUrl,isShowcase,liveUrl,githubUrl,techStack,createdAt,updatedAt,publishedAt,revisedAt",
-			depth: 1, // 関連コンテンツを展開
+			depth: 1,
+			...(draftKey ? { draftKey } : {}),
 		},
 	});
 	return response;


### PR DESCRIPTION
## Summary

- /api/preview 新規作成（secret検証・draftMode有効化・HttpOnly CookieにdraftKey保存）
- /api/exit-preview 新規作成（draftMode無効化・Cookie削除）
- blog/[slug]/page.tsx にdraftMode対応とプレビューバナー追加
- microcms.ts の getBlogPost に draftKey 引数を追加
- .gitignore に /blog/ /doc/ を追加
- pre-existing build fix: USE_MOCK_BLOG=true のとき generateStaticParams をスキップ

## セキュリティ（Codexレビュー反映）

- draftKey を URL に残さず HttpOnly Cookie で管理
- slug バリデーション を両ルートに追加
- MICROCMS_PREVIEW_SECRET 未設定時は 500 を返す

## マージ後に必要な手動設定

1. Vercel 環境変数に MICROCMS_PREVIEW_SECRET を追加（Preview + Production）
2. microCMS 管理画面 > API設定 > コンテンツプレビュー > URL設定:
   https://tanebi-net.com/api/preview?slug={CONTENT_ID}&draftKey={DRAFT_KEY}&secret=（値）

## Test plan

- [x] pnpm dev 起動後、/api/preview?slug=mock-nextjs-app-router&draftKey=test&secret={secret} でバナーが表示される
- [x] DevTools > Cookies > __microcms_preview_draftkey が HttpOnly で存在する
- [x] 「終了する」でバナーが消え Cookie が削除される
- [x] pnpm lint / pnpm build エラーなし