### PR TITLE
feat: @tailwindcss/typographyプラグインを追加（ブログ本文スタイル修正）

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.1.4",
+		"@tailwindcss/typography": "^0.5.19",
 		"@types/node": "^20",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.1.4
         version: 2.1.4
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.17)
       '@types/node':
         specifier: ^20
         version: 20.19.10
@@ -807,6 +810,11 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
@@ -1610,6 +1618,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -2702,6 +2714,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.17)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.17
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/draco3d@1.4.10': {}
@@ -3438,6 +3455,11 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,5 +51,5 @@ export default {
 			},
 		},
 	},
-	plugins: [],
+	plugins: [require("@tailwindcss/typography")],
 } satisfies Config;


### PR DESCRIPTION
## Summary

- `@tailwindcss/typography` プラグインをインストール
- `tailwind.config.ts` の `plugins` に登録
- ブログ記事本文で使用している `prose` クラスが有効になり、h2/h3/p/ul/strong 等のHTMLに適切なタイポグラフィスタイルが適用される

## 背景

ブログ記事ページの本文コンテナに `prose` クラスが使われていたが、typographyプラグイン未インストールのため全スタイルが無効になっていた。見出し・段落・リストが全て同じサイズ・スタイルで表示されていた。

## Test plan

- [ ] ブログ記事ページで h2/h3 が本文より大きく表示されること
- [ ] ul/li にインデントと行間が付くこと
- [ ] strong（太字）が正しく表示されること
- [ ] hr（区切り線）が表示されること
- [ ] 既存ページのレイアウトに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)