### PR TITLE
style: ブログ記事本文のタイポグラフィを改善

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -82,7 +82,7 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 			<Card>
 				<CardContent className="p-6 lg:p-8">
 					<div
-						className="prose dark:prose-invert max-w-none prose-headings:font-bold prose-h2:text-xl prose-h2:mt-8 prose-h2:mb-4 prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-3 prose-p:mb-4 prose-p:leading-relaxed prose-ul:mb-4 prose-ol:mb-4 prose-li:mb-2 prose-code:bg-gray-100 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:overflow-x-auto prose-pre:text-sm prose-blockquote:border-l-4 prose-blockquote:border-gray-300 prose-blockquote:pl-4 prose-img:rounded-lg prose-img:shadow-md prose-lg"
+						className="prose dark:prose-invert max-w-none prose-lg prose-headings:font-bold prose-headings:tracking-tight prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h2:pb-2 prose-h2:border-b prose-h2:border-gray-200 dark:prose-h2:border-gray-700 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3 prose-p:mb-5 prose-p:leading-relaxed prose-ul:mb-4 prose-ol:mb-4 prose-li:mb-2 prose-strong:text-gray-900 dark:prose-strong:text-gray-100 prose-code:bg-gray-100 dark:prose-code:bg-gray-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:overflow-x-auto prose-pre:text-sm prose-blockquote:border-l-4 prose-blockquote:border-gray-300 prose-blockquote:pl-4 prose-blockquote:text-gray-600 prose-img:rounded-lg prose-img:shadow-md prose-hr:my-8"
 					>
 						{typeof post.content === "string" ? (
 							// biome-ignore lint/security/noDangerouslySetInnerHtml: microCMSコンテンツをDOMPurifyでサニタイズ済み


### PR DESCRIPTION
## Summary

- h2: `text-xl`(20px) → `text-2xl`(24px) + 下線 で見出しを視覚的に強調
- h3: `text-lg`(18px) → `text-xl`(20px) で h2 との階層差を明確化
- 余白・行間を調整して長文が読みやすく
- strong（太字）・blockquote・hr のスタイルを補完

## 変更の背景

`prose-h2:text-xl` が本文（prose-lg: 18px）とほぼ同サイズになっており、見出しと本文が視覚的に区別できなかった。

## Test plan

- [ ] h2 が本文より明らかに大きく・下線付きで表示されること
- [ ] h3 が h2 より一回り小さく表示されること
- [ ] 段落間の余白が適切に空くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)