### PR TITLE
fix(blog): ブログ記事の空コンテンツによる黒いバー表示を修正

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -68,6 +68,9 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 		notFound();
 	}
 
+	// DEBUG: コンテンツの型を確認（確認後に削除）
+	console.log('[DEBUG] content type:', typeof post.content, '| value:', JSON.stringify(post.content)?.substring(0, 200));
+
 	// 見出しの数をカウント（4個以上で目次を表示）
 	const countHeadings = (content: string) => {
 		const matches = content.match(/<h[123]/g);
@@ -84,11 +87,15 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 					<div
 						className="prose dark:prose-invert max-w-none prose-lg prose-headings:font-bold prose-headings:tracking-tight prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h2:pb-2 prose-h2:border-b prose-h2:border-gray-200 dark:prose-h2:border-gray-700 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3 prose-p:mb-5 prose-p:leading-relaxed prose-ul:mb-4 prose-ol:mb-4 prose-li:mb-2 prose-strong:text-gray-900 dark:prose-strong:text-gray-100 prose-code:bg-gray-100 dark:prose-code:bg-gray-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:overflow-x-auto prose-pre:text-sm prose-blockquote:border-l-4 prose-blockquote:border-gray-300 prose-blockquote:pl-4 prose-blockquote:text-gray-600 prose-img:rounded-lg prose-img:shadow-md prose-hr:my-8"
 					>
-						{typeof post.content === "string" ? (
+						{!post.content ? (
+							<p className="text-gray-500 dark:text-gray-400">
+								コンテンツは現在準備中です。
+							</p>
+						) : typeof post.content === "string" ? (
 							// biome-ignore lint/security/noDangerouslySetInnerHtml: microCMSコンテンツをDOMPurifyでサニタイズ済み
 							<div dangerouslySetInnerHTML={{ __html: sanitizeHtml(post.content) }} />
 						) : (
-							<pre className="whitespace-pre-wrap bg-gray-100 p-4 rounded">
+							<pre className="not-prose whitespace-pre-wrap bg-gray-100 dark:bg-gray-800 p-4 rounded text-sm">
 								{JSON.stringify(post.content, null, 2)}
 							</pre>
 						)}


### PR DESCRIPTION
## 概要

ブログ記事の `content` フィールドが空/undefined の場合に黒いバーが表示される問題を修正しました。

## 原因

- microCMS の記事で `content` が未入力だと API が `undefined` を返す
- `undefined` は文字列ではないため fallback の `<pre>` に入る
- `<pre>` が prose コンテナの中にあるため `prose-pre:bg-gray-900` が `bg-gray-100` を上書き
- 空の `<pre>` が黒いバーとして表示されていた

## 変更内容

- `!post.content` のケースを先に捕捉し「コンテンツは現在準備中です。」を表示
- JSON fallback の `<pre>` に `not-prose` クラスを追加（prose スタイルの上書き防止）
- ダークモード対応で `<pre>` に `dark:bg-gray-800` を追加
- デバッグコード追加：Vercel ログで `content` の型を確認予定（確認後に削除）

## 動作確認

- [ ] Vercel プレビューでプレビューモードの動作確認
- [ ] Vercel ログで `[DEBUG]` 出力を確認し `content` の型を把握
- [ ] デバッグコード削除後に再コミット

## 本番への影響

なし。既存の公開記事は `content` が文字列で入っているため、従来と同じ `dangerouslySetInnerHTML` パスを通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)