### PR TITLE
release: ブログタイポグラフィ改善・チャットウィジェット・各種修正

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -68,9 +68,6 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 		notFound();
 	}
 
-	// DEBUG: コンテンツの型を確認（確認後に削除）
-	console.log('[DEBUG] content type:', typeof post.content, '| value:', JSON.stringify(post.content)?.substring(0, 200));
-
 	// 見出しの数をカウント（4個以上で目次を表示）
 	const countHeadings = (content: string) => {
 		const matches = content.match(/<h[123]/g);

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -68,6 +68,9 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 		notFound();
 	}
 
+	// DEBUG: コンテンツの型を確認（確認後に削除）
+	console.log('[DEBUG] content type:', typeof post.content, '| value:', JSON.stringify(post.content)?.substring(0, 200));
+
 	// 見出しの数をカウント（4個以上で目次を表示）
 	const countHeadings = (content: string) => {
 		const matches = content.match(/<h[123]/g);
@@ -84,11 +87,15 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 					<div
 						className="prose dark:prose-invert max-w-none prose-lg prose-headings:font-bold prose-headings:tracking-tight prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h2:pb-2 prose-h2:border-b prose-h2:border-gray-200 dark:prose-h2:border-gray-700 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3 prose-p:mb-5 prose-p:leading-relaxed prose-ul:mb-4 prose-ol:mb-4 prose-li:mb-2 prose-strong:text-gray-900 dark:prose-strong:text-gray-100 prose-code:bg-gray-100 dark:prose-code:bg-gray-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:overflow-x-auto prose-pre:text-sm prose-blockquote:border-l-4 prose-blockquote:border-gray-300 prose-blockquote:pl-4 prose-blockquote:text-gray-600 prose-img:rounded-lg prose-img:shadow-md prose-hr:my-8"
 					>
-						{typeof post.content === "string" ? (
+						{!post.content ? (
+							<p className="text-gray-500 dark:text-gray-400">
+								コンテンツは現在準備中です。
+							</p>
+						) : typeof post.content === "string" ? (
 							// biome-ignore lint/security/noDangerouslySetInnerHtml: microCMSコンテンツをDOMPurifyでサニタイズ済み
 							<div dangerouslySetInnerHTML={{ __html: sanitizeHtml(post.content) }} />
 						) : (
-							<pre className="whitespace-pre-wrap bg-gray-100 p-4 rounded">
+							<pre className="not-prose whitespace-pre-wrap bg-gray-100 dark:bg-gray-800 p-4 rounded text-sm">
 								{JSON.stringify(post.content, null, 2)}
 							</pre>
 						)}


### PR DESCRIPTION
## 概要

dev → main へのリリースPRです。直近の複数フィーチャーをまとめて本番反映します。

## 含まれる主な変更

- **fix(blog)**: ブログ記事の空コンテンツ表示を修正（黒いバー → 「準備中」メッセージ表示）
- **style(blog)**: ブログ記事本文のタイポグラフィを改善（h2/h3 サイズ・余白・装飾）
- **feat**: `@tailwindcss/typography` プラグインを追加
- **feat**: Dify チャットウィジェットを追加（iframe版、ロゴ隠しオーバーレイ付き）
- **feat**: microCMS Draft Mode プレビュー機能を実装
- **fix**: llms.txt・JSON-LD・SEO文言をサイト表示と同期
- **refactor**: ヒーロー・ミッション文言の整理

## 動作確認

- [ ] 本番デプロイ後、ブログ記事ページの表示を確認
- [ ] プレビューモードでドラフト記事が正常に表示されることを確認
- [ ] チャットウィジェットの表示を確認

## 注意事項

デバッグコード（`[DEBUG] content type:`）が含まれています。  
本番ログでコンテンツの型を確認後、別PRで削除します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)