### PR TITLE
feat(blog): ブログ記事にJSON-LD構造化データ(BlogPosting)を追加

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -13,7 +13,7 @@ import {
 	type BlogPost,
 	type AuthorProfile,
 } from "@/lib/microcms";
-import { generateBlogMetadata } from "@/lib/seo";
+import { generateBlogJsonLd, generateBlogMetadata } from "@/lib/seo";
 import { sanitizeHtml } from "@/lib/sanitize";
 
 interface BlogDetailPageProps {
@@ -112,8 +112,17 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 		</>
 	);
 
+	const jsonLd = generateBlogJsonLd(post, profile?.name);
+	// </script> ブレイクアウト対策として < をエスケープ
+	const jsonLdHtml = JSON.stringify(jsonLd).replace(/</g, "\\u003c");
+
 	return (
 		<>
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD（< はエスケープ済み）
+			dangerouslySetInnerHTML={{ __html: jsonLdHtml }}
+		/>
 		{isEnabled && (
 			<div className="fixed top-0 left-0 right-0 z-50 bg-yellow-400 text-yellow-900 text-center text-sm py-1 font-medium">
 				プレビューモード —{" "}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -77,6 +77,61 @@ export function generateBlogMetadata(post: BlogPost): Metadata {
 	};
 }
 
+// ブログ記事の構造化データ（JSON-LD / BlogPosting）生成
+// Google のリッチリザルト・生成AI（AIO/LLMO）での可読性向上を目的とする
+export function generateBlogJsonLd(
+	post: BlogPost,
+	authorName?: string,
+): Record<string, unknown> {
+	const description = extractDescription(post.content);
+	const url = `${SITE_CONFIG.url}/blog/${post.id}`;
+	const image = post.eyecatch?.url
+		? post.eyecatch.url
+		: `${SITE_CONFIG.url}${SITE_CONFIG.ogImage}`;
+
+	// 日付のパース時にエラーが出ないように安全策を追加
+	let datePublished = new Date().toISOString();
+	let dateModified = new Date().toISOString();
+	try {
+		if (post.publishedAt)
+			datePublished = new Date(post.publishedAt).toISOString();
+		if (post.updatedAt) dateModified = new Date(post.updatedAt).toISOString();
+	} catch (e) {
+		console.warn("Date parsing error in generateBlogJsonLd", e);
+	}
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		headline: post.title,
+		description,
+		image,
+		datePublished,
+		dateModified,
+		url,
+		mainEntityOfPage: {
+			"@type": "WebPage",
+			"@id": url,
+		},
+		author: {
+			"@type": "Person",
+			name: authorName || SITE_CONFIG.author,
+		},
+		publisher: {
+			"@type": "Organization",
+			"@id": `${SITE_CONFIG.url}/#organization`,
+			name: SITE_CONFIG.author,
+			logo: {
+				"@type": "ImageObject",
+				url: `${SITE_CONFIG.url}/images/favicon.png`,
+			},
+		},
+		...(post.category && post.category.length > 0
+			? { keywords: post.category.join(", ") }
+			: {}),
+	};
+}
+
 export const BLOG_LIST_METADATA: Metadata = {
 	title: "ブログ一覧",
 	description: "技術記事やプロジェクトについての情報を発信しています。",


### PR DESCRIPTION
## 概要
ブログ記事ページに `BlogPosting` の JSON-LD 構造化データを追加し、検索エンジンのリッチリザルトと生成AI（AIO/LLMO）での可読性を向上させる。

## 変更内容
- `src/lib/seo.ts`: `generateBlogJsonLd()` を追加（headline / description / image / datePublished / dateModified / author / publisher / keywords を出力。publisher はトップページの `#organization` を参照）
- `src/app/blog/[slug]/page.tsx`: 記事ページに JSON-LD `<script>` を描画。著者名は取得済みプロフィールを使用
- `</script>` ブレイクアウト対策として `<` を `<` にエスケープして埋め込み

## 動作確認
- `pnpm lint` パス（エラー・警告なし）
- `pnpm build`（dotenvx 復号でmicroCMS取得）でビルド成功・記事ページ(SSG)が正常に生成されることを確認
- 既存機能・レイアウトへの影響なし（追加のみ、表示要素なし）

## 補足
- 既存の記事ページには JSON-LD が未実装で、トップページのみ構造化データを持っていたため、記事側を補完
- 差分は機能追加分のみに限定（リポジトリ全体のフォーマット差分は含めていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)