### PR TITLE
feat(lp): モバイルFV・アコーディオン・ナビメニュー・上に戻るボタンの改善

### DIFF
--- a/src/app/service/components/example-list-accordion.tsx
+++ b/src/app/service/components/example-list-accordion.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+interface ExampleListAccordionProps {
+	items: string[];
+}
+
+/**
+ * 「例えばこんなこと」の例示リスト。
+ * モバイルではタップで開閉するアコーディオン、デスクトップでは常時展開のまま。
+ * ServicePage は metadata を export する Server Component のため、
+ * 開閉状態を持つこの部分だけを Client Component として切り出している。
+ */
+export function ExampleListAccordion({ items }: ExampleListAccordionProps) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<div className="self-start lg:pt-1">
+			<button
+				type="button"
+				onClick={() => setIsOpen((prev) => !prev)}
+				aria-expanded={isOpen}
+				className="flex w-full items-center justify-between gap-2 mb-3 text-left md:pointer-events-none md:cursor-default"
+			>
+				<span className="text-xs font-bold tracking-widest text-muted-foreground">
+					例えばこんなこと
+				</span>
+				<ChevronDown
+					aria-hidden
+					className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform md:hidden ${
+						isOpen ? "rotate-180" : ""
+					}`}
+				/>
+			</button>
+			<div className={`${isOpen ? "block" : "hidden"} md:block`}>
+				<ul>
+					{items.map((item) => (
+						<li
+							key={item}
+							className="flex gap-3 py-3 border-t border-border text-sm leading-relaxed"
+						>
+							<span aria-hidden className="text-[#e8590c]">
+								—
+							</span>
+							{item}
+						</li>
+					))}
+				</ul>
+				<p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+					その他、課題に感じていることがありましたら、
+					<br />
+					<Link
+						href="/#contact"
+						className="font-bold text-foreground underline underline-offset-4 hover:text-[#e8590c] transition-colors"
+					>
+						お気軽にご相談ください
+					</Link>
+					。
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/app/service/components/scroll-to-top-button.tsx
+++ b/src/app/service/components/scroll-to-top-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { ArrowUp } from "lucide-react";
+import { useEffect, useState } from "react";
+
+/**
+ * /service, /service/issues 用の「上に戻る」ボタン。
+ *
+ * ルートレイアウトの ChatWidget（UFOボタン、fixed bottom-6 right-6, 64px四方）と
+ * 重ならないよう、その上に表示する。既存の src/components/blog/scroll-to-top.tsx は
+ * bottom-6 right-6 のままで ChatWidget と重なる位置にあるため、そちらは真似ていない。
+ */
+export function ScrollToTopButton() {
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		const handleScroll = () => setVisible(window.scrollY > 300);
+		handleScroll();
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
+
+	if (!visible) return null;
+
+	return (
+		<button
+			type="button"
+			onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+			className="fixed bottom-28 right-6 z-40 w-12 h-12 rounded-full bg-foreground text-background shadow-lg flex items-center justify-center hover:opacity-90 transition-opacity"
+			aria-label="ページ上部に戻る"
+		>
+			<ArrowUp className="w-5 h-5" />
+		</button>
+	);
+}

--- a/src/app/service/components/scroll-to-top-button.tsx
+++ b/src/app/service/components/scroll-to-top-button.tsx
@@ -9,6 +9,10 @@ import { useEffect, useState } from "react";
  * ルートレイアウトの ChatWidget（UFOボタン、fixed bottom-6 right-6, 64px四方）と
  * 重ならないよう、その上に表示する。既存の src/components/blog/scroll-to-top.tsx は
  * bottom-6 right-6 のままで ChatWidget と重なる位置にあるため、そちらは真似ていない。
+ *
+ * デスクトップ(md:)では sidebar-menu.tsx の折りたたみ状態が画面右端に
+ * 常時 80px 幅の帯として表示される（md:w-[80px] md:h-screen）。right-6 のままだと
+ * この帯の内側（下）に隠れてしまうため、md:right-24 で帯の左（内側）に逃がす。
  */
 export function ScrollToTopButton() {
 	const [visible, setVisible] = useState(false);
@@ -26,7 +30,7 @@ export function ScrollToTopButton() {
 		<button
 			type="button"
 			onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-			className="fixed bottom-28 right-6 z-40 w-12 h-12 rounded-full bg-foreground text-background shadow-lg flex items-center justify-center hover:opacity-90 transition-opacity"
+			className="fixed bottom-28 right-6 md:right-24 z-40 w-12 h-12 rounded-full bg-foreground text-background shadow-lg flex items-center justify-center hover:opacity-90 transition-opacity"
 			aria-label="ページ上部に戻る"
 		>
 			<ArrowUp className="w-5 h-5" />

--- a/src/app/service/layout.tsx
+++ b/src/app/service/layout.tsx
@@ -1,6 +1,14 @@
 import type { ReactNode } from "react";
 import { LpLightScope } from "@/components/lp/LpLightScope";
+import { ScrollToTopButton } from "./components/scroll-to-top-button";
 
+// この layout は /service と /service/issues の両方に効く（issues は /service 配下のため）。
+// /works は別の layout.tsx を持つため対象外。
 export default function ServiceLayout({ children }: { children: ReactNode }) {
-	return <LpLightScope>{children}</LpLightScope>;
+	return (
+		<LpLightScope>
+			{children}
+			<ScrollToTopButton />
+		</LpLightScope>
+	);
 }

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -12,6 +12,7 @@ import { CtaBlock } from "@/components/lp/CtaBlock";
 import { anton, notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
+import { ExampleListAccordion } from "./components/example-list-accordion";
 
 export const metadata: Metadata = {
 	title: "できること ─ ご相談メニュー | TANEBI CREATIVE",
@@ -202,35 +203,7 @@ export default function ServicePage() {
 										</p>
 									)}
 								</div>
-								<div className="self-start lg:pt-1">
-									<p className="text-xs font-bold tracking-widest text-muted-foreground mb-3">
-										例えばこんなこと
-									</p>
-									<ul>
-										{menu.items.map((item) => (
-											<li
-												key={item}
-												className="flex gap-3 py-3 border-t border-border text-sm leading-relaxed"
-											>
-												<span aria-hidden className="text-[#e8590c]">
-													—
-												</span>
-												{item}
-											</li>
-										))}
-									</ul>
-									<p className="mt-4 text-xs leading-relaxed text-muted-foreground">
-										その他、課題に感じていることがありましたら、
-										<br />
-										<Link
-											href="/#contact"
-											className="font-bold text-foreground underline underline-offset-4 hover:text-[#e8590c] transition-colors"
-										>
-											お気軽にご相談ください
-										</Link>
-										。
-									</p>
-								</div>
+								<ExampleListAccordion items={menu.items} />
 							</div>
 						</div>
 					))}

--- a/src/components/lp/LpLightScope.tsx
+++ b/src/components/lp/LpLightScope.tsx
@@ -1,4 +1,16 @@
+"use client";
+
+import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
+
+// HomeClient と同じくクライアント専用（framer-motion + gsap）なので動的インポートにする。
+// onNavigate は渡さない。LP上ではトップページ内セクションへのリンクは
+// 通常のリンク（/#hash）としてナビゲートすればよく、トップページ限定のスムーズスクロール
+// インターセプトは不要なため（sidebar-menu.tsx 側で onNavigate 有無により分岐している）。
+const SidebarMenu = dynamic(
+	() => import("@/components/ui/sidebar-menu").then((mod) => mod.SidebarMenu),
+	{ ssr: false },
+);
 
 /**
  * LPページをライト固定で描画するためのスコープ。
@@ -8,10 +20,14 @@ import type { ReactNode } from "react";
  * ページ内にテーマ切替ボタンも置いていないため）。
  * html に .dark が付いた状態でそのまま描くと、本文がほぼ白・カードが濃紺になり読めなくなる。
  * .lp-light（globals.css）でライトのトークンを再定義し、この階層以下だけ切り離す。
+ *
+ * ナビゲーションメニューはトップページ（HomeClient）にしかマウントされていなかったため、
+ * LP配下ではハンバーガーメニュー自体が存在しなかった。ここに追加して他ページと揃える。
  */
 export function LpLightScope({ children }: { children: ReactNode }) {
 	return (
 		<div className="lp-light min-h-screen bg-background text-foreground">
+			<SidebarMenu />
 			{children}
 		</div>
 	);

--- a/src/components/lp/PageHero.tsx
+++ b/src/components/lp/PageHero.tsx
@@ -45,8 +45,8 @@ export function PageHero({
 
 			{/* min-h はリード文が最長のページ(/service/issues)基準。全ページで第一画面の高さを揃える */}
 			<div className="grid grid-cols-1 lg:grid-cols-[5fr_6fr] gap-10 lg:gap-16 items-center lg:min-h-[540px]">
-				{/* ビジュアル枠（画像支給までは種火プレースホルダー） */}
-				<div className="order-2 lg:order-1">
+				{/* ビジュアル枠（画像支給までは種火プレースホルダー）。モバイルでも画像を先頭に出す */}
+				<div className="order-1">
 					{visual ? (
 						<Image
 							src={visual.src}
@@ -88,7 +88,7 @@ export function PageHero({
 					)}
 				</div>
 
-				<div className="order-1 lg:order-2">
+				<div className="order-2">
 					<p
 						className={`${anton.className} text-sm tracking-[0.3em] uppercase text-[#e8590c] mb-4`}
 					>

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -255,12 +255,14 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 								</button>
 							</div>
 
-							{/* SPは中央寄せ(元の挙動のまま)、PCだけ上詰め。
-						    CONTACTとUFOボタン(ChatWidget)の衝突は中央寄せの変更ではなく
-						    Menu Content Container の pb-28（下部クリアランス）で対処している。
-						    PCの項目間隔(gap)は画面の高さに応じて可変（詳細はitem labelのコメント参照）。
-						    画面高さ800px以上では md:space-y-6 相当(24px)のまま、それより低い画面では縮む */}
-						<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh,1.5rem)] flex-1 justify-center items-center md:justify-start md:items-start w-full">
+							{/* SP・PCとも上下左右中央寄せ。
+						    justify-center は内容が溢れると上端が見切れて到達できなくなる懸念があるが、
+						    nav は flex-1（min-height:auto）なので内容が多い場合は nav 自体が伸び、
+						    親コンテナ側の overflow-y-auto によるスクロールになる。よって見切れは起きない。
+						    CONTACTとUFOボタン(ChatWidget)の衝突は Menu Content Container の
+						    pb-28（下部クリアランス）で対処している。
+						    PCの項目間隔(gap)は画面の高さに応じて可変（詳細はitem labelのコメント参照） */}
+						<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh,1.5rem)] flex-1 justify-center items-center w-full">
 								{menuItems.map((item, i) => (
 									<motion.div
 										key={item.href}

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -257,8 +257,10 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 
 							{/* SPは中央寄せ(元の挙動のまま)、PCだけ上詰め。
 						    CONTACTとUFOボタン(ChatWidget)の衝突は中央寄せの変更ではなく
-						    Menu Content Container の pb-28（下部クリアランス）で対処している */}
-						<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-center items-center md:justify-start md:items-start w-full">
+						    Menu Content Container の pb-28（下部クリアランス）で対処している。
+						    PCの項目間隔(gap)は画面の高さに応じて可変（詳細はitem labelのコメント参照）。
+						    画面高さ800px以上では md:space-y-6 相当(24px)のまま、それより低い画面では縮む */}
+						<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh_+_0.25rem,1.5rem)] flex-1 justify-center items-center md:justify-start md:items-start w-full">
 								{menuItems.map((item, i) => (
 									<motion.div
 										key={item.href}
@@ -315,7 +317,12 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 												</div>
 
 												{/* Label */}
-												<span className="text-4xl md:text-5xl font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
+												{/* PC(md:)は画面の高さに応じて文字サイズが可変。項目が6個になり、低い画面高さでは
+												    text-5xl(48px)固定だと下スクロールが発生しうるため、
+												    clamp(下限28px, 4dvh+16px, 上限48px=text-5xl相当) にした。
+												    画面高さ800px以上ではこれまで通り48pxのまま、低い画面だけ縮んで
+												    常に画面内(下スクロール無し)に収まるようにしている。SPには影響しない */}
+												<span className="text-4xl md:text-[clamp(1.75rem,4dvh_+_1rem,3rem)] font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
 													{item.label}
 												</span>
 

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -260,7 +260,7 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 						    Menu Content Container の pb-28（下部クリアランス）で対処している。
 						    PCの項目間隔(gap)は画面の高さに応じて可変（詳細はitem labelのコメント参照）。
 						    画面高さ800px以上では md:space-y-6 相当(24px)のまま、それより低い画面では縮む */}
-						<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh_+_0.25rem,1.5rem)] flex-1 justify-center items-center md:justify-start md:items-start w-full">
+						<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh,1.5rem)] flex-1 justify-center items-center md:justify-start md:items-start w-full">
 								{menuItems.map((item, i) => (
 									<motion.div
 										key={item.href}
@@ -304,9 +304,13 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 											className="group relative block w-full md:w-[400px]"
 										>
 											{/* Desktop Hover Card: White Background, Icon Pops Up */}
+											{/* md:py-[clamp(...)] は p-6 の上下だけを打ち消す指定。
+											    p-6(上下24pxずつ=1項目あたり48px)を6項目ぶん固定で積むと、
+											    ノートPC相当の画面高さ(800px前後)でメニューが画面内に収まらなくなるため、
+											    上下パディングも画面の高さに応じて可変にしている。左右のpaddingはp-6のまま */}
 											<div
 												className="
-                                                hidden md:flex flex-col items-center justify-center p-6 rounded-xl transition-all duration-300
+                                                hidden md:flex flex-col items-center justify-center p-6 md:py-[clamp(0.375rem,1.5dvh,1.5rem)] rounded-xl transition-all duration-300
                                                 text-white
                                                 md:hover:text-[#60d5fa]
                                             "
@@ -326,7 +330,7 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 												    セットで定義されるが、text-[clamp(...)] のようなアービトラリ値は font-size しか
 												    指定されず、html の line-height:1.5 を継承してしまう（48px想定が実際72pxになり、
 												    計算上収まるはずの高さでも下スクロールが発生していた） */}
-												<span className="text-4xl md:text-[clamp(1.75rem,4dvh_+_1rem,3rem)] md:leading-none font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
+												<span className="text-4xl md:text-[clamp(1.75rem,5dvh,3rem)] md:leading-none font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
 													{item.label}
 												</span>
 

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -235,7 +235,7 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 							style={{ height: "100dvh" }} // モバイルアドレスバー対応
 						>
 							{/* Close Button Area */}
-							<div className="absolute top-8 right-2 w-[50px] h-[50px] flex items-center justify-center z-50 md:static md:w-full md:h-auto md:block md:text-right md:mb-12">
+							<div className="absolute top-4 right-1 w-[50px] h-[50px] flex items-center justify-center z-50 md:static md:w-full md:h-auto md:block md:text-right md:mb-12">
 								<button
 									onClick={handleClose}
 									className="p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors text-white"
@@ -251,10 +251,10 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 								</button>
 							</div>
 
-							{/* デスクトップも中央寄せに統一。以前は md:items-start md:justify-start（上詰め）だったが、
-						    項目を4→6個に増やした際に上に偏って見えたため。中央寄せなら項目数が変わっても
-						    自動でバランスが取れる */}
-						<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-center items-center w-full">
+							{/* 中央寄せは意図した見た目と違ったため上詰めに戻した。
+						    CONTACTとUFOボタン(ChatWidget)の衝突は、中央寄せではなく
+						    Menu Content Container の pb-28（下部クリアランス）で別途対処済み */}
+						<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-start items-center w-full">
 								{menuItems.map((item, i) => (
 									<motion.div
 										key={item.href}

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -229,13 +229,17 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 
 						{/* Menu Content Container */}
 						{/* pb-28 は ChatWidget の UFOボタン(bottom-6 right-6, 64px四方)との衝突を避けるための下部クリアランス。
-						    overflow-y-auto は項目数が増えた場合の保険（100dvh に収まらなくても隠れずスクロールできる） */}
+						    overflow-y-auto は項目数が増えた場合の保険（100dvh に収まらなくても隠れずスクロールできる）。
+						    md:p-12 は使わない。PCもSPと同じ2rem(p-8)にする（devtoolsでの確認・指示どおり） */}
 						<div
-							className="fixed top-0 right-0 w-full max-w-[450px] z-50 flex flex-col overflow-y-auto p-8 pb-28 md:p-12 md:pb-28 pointer-events-auto"
+							className="fixed top-0 right-0 w-full max-w-[450px] z-50 flex flex-col overflow-y-auto p-8 pb-28 pointer-events-auto"
 							style={{ height: "100dvh" }} // モバイルアドレスバー対応
 						>
-							{/* Close Button Area */}
-							<div className="absolute top-4 right-1 w-[50px] h-[50px] flex items-center justify-center z-50 md:static md:w-full md:h-auto md:block md:text-right md:mb-12">
+							{/* Close Button Area
+							    top-8 right-2 は SP(position:absolute)用。md:static になるPCでは
+							    position:static のため top/right は効かない。PC側の余白は md:mb-12 が
+							    作っていたが不要とのことなので削除した */}
+							<div className="absolute top-8 right-2 w-[50px] h-[50px] flex items-center justify-center z-50 md:static md:w-full md:h-auto md:block md:text-right">
 								<button
 									onClick={handleClose}
 									className="p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors text-white"
@@ -251,10 +255,10 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 								</button>
 							</div>
 
-							{/* 中央寄せは意図した見た目と違ったため上詰めに戻した。
-						    CONTACTとUFOボタン(ChatWidget)の衝突は、中央寄せではなく
-						    Menu Content Container の pb-28（下部クリアランス）で別途対処済み */}
-						<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-start items-center w-full">
+							{/* SPは中央寄せ(元の挙動のまま)、PCだけ上詰め。
+						    CONTACTとUFOボタン(ChatWidget)の衝突は中央寄せの変更ではなく
+						    Menu Content Container の pb-28（下部クリアランス）で対処している */}
+						<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-center items-center md:justify-start md:items-start w-full">
 								{menuItems.map((item, i) => (
 									<motion.div
 										key={item.href}

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -321,8 +321,12 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 												    text-5xl(48px)固定だと下スクロールが発生しうるため、
 												    clamp(下限28px, 4dvh+16px, 上限48px=text-5xl相当) にした。
 												    画面高さ800px以上ではこれまで通り48pxのまま、低い画面だけ縮んで
-												    常に画面内(下スクロール無し)に収まるようにしている。SPには影響しない */}
-												<span className="text-4xl md:text-[clamp(1.75rem,4dvh_+_1rem,3rem)] font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
+												    常に画面内(下スクロール無し)に収まるようにしている。SPには影響しない。
+												    md:leading-none が必須。text-5xl 等の既定クラスは font-size と line-height が
+												    セットで定義されるが、text-[clamp(...)] のようなアービトラリ値は font-size しか
+												    指定されず、html の line-height:1.5 を継承してしまう（48px想定が実際72pxになり、
+												    計算上収まるはずの高さでも下スクロールが発生していた） */}
+												<span className="text-4xl md:text-[clamp(1.75rem,4dvh_+_1rem,3rem)] md:leading-none font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
 													{item.label}
 												</span>
 

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -3,7 +3,16 @@
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
-import { Menu, X, Home, Rocket, User, Bird } from "lucide-react";
+import {
+	Menu,
+	X,
+	Home,
+	Rocket,
+	User,
+	Bird,
+	Wrench,
+	Lightbulb,
+} from "lucide-react";
 import gsap from "gsap";
 
 interface SidebarMenuProps {
@@ -26,22 +35,38 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 		setIsClosing(false);
 	};
 
+	// /mission, /about, /contact はトップページ内のセクションで、実URLとしては存在しない。
+	// href はハッシュ形式にしておくことで、LP等の別ページから開いたときも
+	// 通常のリンクとして /#hash 経由でトップの該当セクションへ飛べるようにする。
+	// トップページ上での挙動（スムーズスクロール）は onClick 側で別途インターセプトする。
 	const menuItems = [
 		{ href: "/", label: "TOP", icon: Home, description: "トップページ" },
 		{
-			href: "/mission",
+			href: "/service",
+			label: "SERVICE",
+			icon: Wrench,
+			description: "できること・ご相談メニュー",
+		},
+		{
+			href: "/service/issues",
+			label: "ISSUES",
+			icon: Lightbulb,
+			description: "その課題、ここから伸ばせます",
+		},
+		{
+			href: "/#mission",
 			label: "MISSION",
 			icon: Rocket,
 			description: "目指すもの",
 		},
 		{
-			href: "/about",
+			href: "/#about",
 			label: "ABOUT",
 			icon: User,
 			description: "TANEBI CREATIVEについて",
 		},
 		{
-			href: "/contact",
+			href: "/#contact",
 			label: "CONTACT",
 			icon: Bird,
 			description: "お気軽にお問い合わせください",
@@ -249,14 +274,18 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 											href={item.href}
 											onClick={(e) => {
 												if (onNavigate) {
-													if (
-														item.href === "/" ||
-														item.href === "/about" ||
-														item.href === "/mission" ||
-														item.href === "/contact"
-													) {
+													// トップページ上でのみ、これらはスムーズスクロールにインターセプトする。
+													// onNavigate 側は従来どおり /about 等の非ハッシュ形式で判定しているため、
+													// ここで # を外してから渡す（LP側の href 自体はハッシュ形式のまま維持する）
+													const topPageTargets = [
+														"/",
+														"/#mission",
+														"/#about",
+														"/#contact",
+													];
+													if (topPageTargets.includes(item.href)) {
 														e.preventDefault();
-														onNavigate(item.href);
+														onNavigate(item.href.replace(/^\/#/, "/"));
 													}
 												}
 												setIsOpen(false);

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -228,8 +228,10 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 						/>
 
 						{/* Menu Content Container */}
+						{/* pb-28 は ChatWidget の UFOボタン(bottom-6 right-6, 64px四方)との衝突を避けるための下部クリアランス。
+						    overflow-y-auto は項目数が増えた場合の保険（100dvh に収まらなくても隠れずスクロールできる） */}
 						<div
-							className="fixed top-0 right-0 w-full max-w-[450px] z-50 flex flex-col p-8 md:p-12 pointer-events-auto"
+							className="fixed top-0 right-0 w-full max-w-[450px] z-50 flex flex-col overflow-y-auto p-8 pb-28 md:p-12 md:pb-28 pointer-events-auto"
 							style={{ height: "100dvh" }} // モバイルアドレスバー対応
 						>
 							{/* Close Button Area */}
@@ -249,7 +251,10 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 								</button>
 							</div>
 
-							<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-center items-center md:items-start md:justify-start md:flex-initial w-full">
+							{/* デスクトップも中央寄せに統一。以前は md:items-start md:justify-start（上詰め）だったが、
+						    項目を4→6個に増やした際に上に偏って見えたため。中央寄せなら項目数が変わっても
+						    自動でバランスが取れる */}
+						<nav className="flex flex-col space-y-4 md:space-y-6 flex-1 justify-center items-center w-full">
 								{menuItems.map((item, i) => (
 									<motion.div
 										key={item.href}


### PR DESCRIPTION
## 概要

LP のモバイル表示改善と、ナビゲーションメニューの拡充・不具合修正。

## 主な変更

- **モバイルで FV 画像をリード文より先に表示**（PageHero 共通、3ページとも）
- **/service の「例えばこんなこと」をモバイルでアコーディオン化**（タップで開閉、デスクトップは常時展開）
- **ハンバーガーメニューに SERVICE・ISSUES を追加し、LPページにも表示**（これまでトップページにしかマウントされていなかった。/works は noindex・再設計中のため見送り）
- **/service /service/issues に追従する「上に戻る」ボタンを追加**（UFOボタン・PCメニュー帯と重ならない位置）
- **PCメニューが画面の高さに関わらずスクロール無しで収まるように**（文字サイズ・項目間隔・カード上下paddingを clamp() で可変化。アービトラリ値に line-height が付かない問題も修正）
- メニュー項目を上下左右中央寄せに統一

## 検証

- pnpm lint / pnpm exec tsc --noEmit エラー0件
- 生成CSSで3つの clamp() の出力と p-6 の上書き順を確認
- ノートPC・デスクトップでの表示をユーザーが実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n