### PR TITLE
fix(seo): 記事0件の /blog を sitemap から除外

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,12 +13,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 1,
 		},
 		{
-			url: `${SITE_URL}/blog`,
-			lastModified: new Date(),
-			changeFrequency: "daily",
-			priority: 0.8,
-		},
-		{
 			url: `${SITE_URL}/service`,
 			lastModified: new Date(),
 			changeFrequency: "monthly",


### PR DESCRIPTION
## 概要

microCMS の記事が0件のまま、/blog の一覧ページが priority 0.8 / changeFrequency daily で sitemap に載っていた（/works と違い noindex も無し）。空の一覧を毎日クロールさせる状態を解消する。

## 変更

- src/app/sitemap.ts から /blog の静的エントリを削除（6行）
- 記事の動的エントリを生成する処理は残してあるので、記事が入れば個別URLは自動で載る
- robots.txt は変更なし。ページ自体は従来どおり表示できる
- **記事を公開したら /blog のエントリを戻すこと**（doc/progress.md に記録済み）

## 検証

- ビルドした sitemap.xml に `<loc>https://tanebi-net.com/blog</loc>` の厳密一致が0件であることを確認
- dev への rebase 時に PR #169 の /service 2エントリとの衝突を解消済み（/service 系は残し /blog のみ削除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n