### PR TITLE
perf: LoadingScreenの2.5秒固定演出を0.7秒に短縮しスクロール封鎖を撤去

### DIFF
--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -101,7 +101,6 @@ export default function HomeClient() {
 
 	// 他ページ（LPのCTAなど）から `/#contact` でアクセスされた場合、Contactセクションへ直行する。
 	// smoothスクロールだと1000vh分の移動が不安定なため、/mission と同じスナップ方式で瞬時に移動する。
-	// また、LoadingScreen表示中は body が overflow:hidden でスクロールできないため、解除されるまで待つ。
 	// biome-ignore lint/correctness/useExhaustiveDependencies: 初回マウント時のみ実行したいため依存に含めない
 	useEffect(() => {
 		if (window.location.hash !== "#contact") return;
@@ -110,11 +109,6 @@ export default function HomeClient() {
 
 		const jumpToContact = () => {
 			if (cancelled) return;
-			if (document.body.style.overflow === "hidden") {
-				// LoadingScreenがスクロールをロックしている間はリトライ
-				setTimeout(jumpToContact, 300);
-				return;
-			}
 			setIsCircleFullyExpanded(true);
 			setShouldSnapAnimation(true);
 			window.scrollTo({

--- a/src/components/loading/LoadingScreen.tsx
+++ b/src/components/loading/LoadingScreen.tsx
@@ -10,18 +10,12 @@ export default function LoadingScreen({
 	const [progress, setProgress] = useState(0);
 	const [hasStarted, setHasStarted] = useState(false);
 
-	// スクロール無効化。unmount 時に必ず戻す
-	// （cleanup がないと、遷移や例外で unmount したときスクロールが戻らなくなる）
-	useEffect(() => {
-		document.body.style.overflow = "hidden";
-		return () => {
-			document.body.style.overflow = "unset";
-		};
-	}, []);
+	// スクロールは封鎖しない。演出中でも読み始められるようにするため。
+	// 以前は document.body.style.overflow = "hidden" で止めていたが、
+	// 実ロードと無関係な演出のためにスクロールを奪う理由がない。
 
 	const handleStart = useCallback(() => {
 		setHasStarted(true);
-		document.body.style.overflow = "unset";
 		// フェードアウト(transition-opacity duration-500)を再生しきってから親に完了を伝える。
 		// 以前は 0ms で通知していたため、親が即座に unmount しフェードが走っていなかった。
 		setTimeout(() => {

--- a/src/components/loading/LoadingScreen.tsx
+++ b/src/components/loading/LoadingScreen.tsx
@@ -22,17 +22,17 @@ export default function LoadingScreen({
 	const handleStart = useCallback(() => {
 		setHasStarted(true);
 		document.body.style.overflow = "unset";
-		// フェードアウト(transition-opacity duration-1000)を再生しきってから親に完了を伝える。
+		// フェードアウト(transition-opacity duration-500)を再生しきってから親に完了を伝える。
 		// 以前は 0ms で通知していたため、親が即座に unmount しフェードが走っていなかった。
 		setTimeout(() => {
 			onLoadingComplete();
-		}, 1000);
+		}, 500);
 	}, [onLoadingComplete]);
 
-	// 約2秒で完了するプログレスシミュレーション
+	// 約0.7秒で完了するプログレスシミュレーション
 	useEffect(() => {
 		const start = performance.now();
-		const duration = 2000;
+		const duration = 700;
 		let frame: number;
 
 		const tick = () => {
@@ -56,16 +56,13 @@ export default function LoadingScreen({
 	// 100%到達で完了
 	useEffect(() => {
 		if (progress === 100) {
-			const timer = setTimeout(() => {
-				handleStart();
-			}, 500);
-			return () => clearTimeout(timer);
+			handleStart();
 		}
 	}, [progress, handleStart]);
 
 	return (
 		<div
-			className={`fixed inset-0 z-50 bg-black transition-opacity duration-1000 ${
+			className={`fixed inset-0 z-50 bg-black transition-opacity duration-500 ${
 				hasStarted ? "opacity-0 pointer-events-none" : "opacity-100"
 			}`}
 		>

--- a/src/components/loading/LoadingScreen.tsx
+++ b/src/components/loading/LoadingScreen.tsx
@@ -10,24 +10,24 @@ export default function LoadingScreen({
 	const [progress, setProgress] = useState(0);
 	const [hasStarted, setHasStarted] = useState(false);
 
-	// スクロール無効化
+	// スクロール無効化。unmount 時に必ず戻す
+	// （cleanup がないと、遷移や例外で unmount したときスクロールが戻らなくなる）
 	useEffect(() => {
 		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = "unset";
+		};
 	}, []);
 
-	const handleStart = useCallback(
-		(immediate = false) => {
-			setHasStarted(true);
-			document.body.style.overflow = "unset";
-			setTimeout(
-				() => {
-					onLoadingComplete();
-				},
-				immediate ? 0 : 1000,
-			);
-		},
-		[onLoadingComplete],
-	);
+	const handleStart = useCallback(() => {
+		setHasStarted(true);
+		document.body.style.overflow = "unset";
+		// フェードアウト(transition-opacity duration-1000)を再生しきってから親に完了を伝える。
+		// 以前は 0ms で通知していたため、親が即座に unmount しフェードが走っていなかった。
+		setTimeout(() => {
+			onLoadingComplete();
+		}, 1000);
+	}, [onLoadingComplete]);
 
 	// 約2秒で完了するプログレスシミュレーション
 	useEffect(() => {
@@ -57,7 +57,7 @@ export default function LoadingScreen({
 	useEffect(() => {
 		if (progress === 100) {
 			const timer = setTimeout(() => {
-				handleStart(true);
+				handleStart();
 			}, 500);
 			return () => clearTimeout(timer);
 		}


### PR DESCRIPTION
## 概要

トップページの LoadingScreen は実ロードと無関係な演出で、回線速度に関係なく本文到達を最短2.5秒ブロックし、その間スクロールも封鎖していた。Lighthouse（モバイル・スロットリング）で LCP 20.2s / TBT 1,710ms の主因だったため修正。

## 変更（3コミット）

1. **fix: フェードが再生されない不具合と cleanup 漏れ** — `handleStart(true)` が 0ms で親に通知して即 unmount され `duration-1000` のフェードが走っていなかった。`overflow:hidden` を設定する useEffect に cleanup が無く、途中 unmount でスクロールが戻らないバグも修正
2. **perf: 演出 2000ms→700ms、100%後の待機 500ms→0、フェード 1000ms→500ms** — タイムライン: 0ms 表示 → 700ms フェード開始 → 1200ms unmount
3. **perf: スクロール封鎖を撤去** — `document.body.style.overflow` の操作を全削除。HomeClient の `/#contact` ジャンプ処理から overflow を見る 300ms リトライも削除（封鎖をやめれば空振りは発生しない。MissionSection の展開待ち setTimeout は残置）

## 実測（Lighthouse モバイル・ローカル本番ビルド・3回実行で安定確認）

| 指標 | 変更前 | 変更後 |
|---|---|---|
| Performance スコア | 46 | 88〜92 |
| LCP | 20.2 s | 3.3 s |
| TBT | 1,710 ms | 110〜230 ms |
| TTI | 20.2 s | 6.5〜6.7 s |

## 検証

- pnpm lint / tsc / build（NEXT_DIST_DIR 分離）エラー0件
- /blog /service のスコアに変化がないこと（回帰なし）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n