### PR TITLE
perf: AboutThreeImage を動的インポート化しトップのJS実行を4.2秒削減

### DIFF
--- a/src/app/components/AboutSection.tsx
+++ b/src/app/components/AboutSection.tsx
@@ -1,8 +1,23 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 
-import AboutThreeImage from "./AboutThreeImage";
+// AboutThreeImage は @react-three/fiber / drei / three を静的に読む。
+// AboutSection -> MissionSection -> HomeClient と静的につながっているため、
+// 静的インポートのままだとトップの初期HTMLに three-vendor(生766KB)が
+// <script async> として出力され、4xCPUスロットル下で約4.2秒のJS実行になっていた。
+// この要素は absolute inset-0 で配置され、ページ最下部の About セクションにしか
+// 出ないため、動的インポートで初期のクリティカルパスから外す。
+//
+// 過去に一度この変更で Canvas が描画されなくなり revert したが、原因は
+// AboutThreeImage の Canvas 内に Suspense 境界が無く、useTexture のサスペンドが
+// この dynamic の境界まで伝播して Canvas ごとアンマウントされていたため。
+// 前コミットで Canvas 内に Suspense を追加して解消済み。
+const AboutThreeImage = dynamic(() => import("./AboutThreeImage"), {
+	ssr: false,
+	loading: () => <div className="absolute inset-0" aria-hidden />,
+});
 
 interface AboutSectionProps {
 	transitionProgress?: number; // 0 -> 1 during Iris Close

--- a/src/app/components/AboutThreeImage.tsx
+++ b/src/app/components/AboutThreeImage.tsx
@@ -9,7 +9,7 @@ import {
 } from "@react-three/fiber";
 import { shaderMaterial, useTexture } from "@react-three/drei";
 import * as THREE from "three";
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, Suspense } from "react";
 
 // --- Shader Definition ---
 const AboutImageShaderMaterial = shaderMaterial(
@@ -263,7 +263,13 @@ export default function AboutThreeImage({
 					height: "100%",
 				}}
 			>
-				<ImageMesh imageSrc={imageSrc} scale={scale} offset={offset} />
+				{/* ImageMesh は useTexture でサスペンドする。Canvas の内側に境界を置かないと
+				    サスペンドが Canvas の外まで伝播し、外側の境界（動的インポートの Suspense 等）が
+				    fallback に切り替わった際に Canvas ごとアンマウントされて WebGL コンテキストが失われる。
+				    hero-canvas.tsx が Astronaut 等で同じ形を取っているのに合わせる */}
+				<Suspense fallback={null}>
+					<ImageMesh imageSrc={imageSrc} scale={scale} offset={offset} />
+				</Suspense>
 			</Canvas>
 		</div>
 	);


### PR DESCRIPTION
## 概要

トップページの実行時パフォーマンスの最大要因だった Three.js の初期ロードを解消。実スロットリング計測で TBT を 1,130ms → 80ms（-93%）に改善。

## 経緯：計測方法の見直しで優先順位が変わった

当初は「/service の FCP 5.3秒」を残課題としていたが、これは Lighthouse 既定のシミュレーション（Lantern）による推定値だった。実スロットリング（`--throttling-method=devtools`）で測り直すと以下の通りで、**実際にはトップページの方が悪い**ことが判明したため対象を変更した。

| ページ | シミュレーション | 実スロットリング |
|---|---|---|
| `/` | FCP 0.8s / スコア92 | FCP 1.8s / TBT **1,130ms** / スコア**73** |
| `/service` | FCP **5.3s** / スコア63 | FCP 2.3s / TBT 570ms / スコア**82** |

## 原因

`AboutSection` → `MissionSection` → `HomeClient` と静的につながっているため、`AboutThreeImage` が読む three-vendor（生766KB）がトップの初期HTMLに `<script async>` として出力され、4xCPUスロットル下で約4.2秒のJS実行になっていた。

## 変更（2コミット）

1. **fix(three): AboutThreeImage の Canvas 内に Suspense 境界を追加**
   `ImageMesh` は `useTexture` でサスペンドするが Canvas 内に Suspense が無く、サスペンドが Canvas の外まで伝播していた。`hero-canvas.tsx` は Astronaut 等4箇所で Canvas 内 Suspense を使っており、本来こちらも同じ形であるべきだった。単体では挙動不変。
2. **perf: AboutThreeImage を動的インポート化**
   過去に同じ変更で Canvas が描画されず revert したが、原因は上記の Suspense 欠如により **dynamic の Suspense 境界が fallback に切り替わった際に Canvas ごとアンマウントされ WebGL コンテキストが失われていた**ため。1 で解消済み。

## 実測

| 指標 | 変更前 | 変更後 |
|---|---|---|
| スコア（実スロットリング） | 73 | **91** |
| TBT | 1,130 ms | **80 ms（-93%）** |
| メインスレッド総時間 | 13.3 s | **2.2 s（-83%）** |
| three.js の実行時間 | 4,256 ms | 625 ms |
| スコア（シミュレーション） | 92 | **97** |
| LCP（シミュレーション） | 3.3 s | 2.3 s |

初期HTMLから three-vendor が消えたことをビルド出力で確認済み。

## 検証

- pnpm lint / tsc エラー0件
- **About セクションの背景描画（前回の失敗箇所）・ヒーローの3D・モバイル幅での表示をユーザーが実機確認済み**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n