### PR TITLE
fix(seo): MissionContent をSSRに戻し事業説明を初期HTMLに出力する

### DIFF
--- a/src/app/components/MissionSection.tsx
+++ b/src/app/components/MissionSection.tsx
@@ -13,9 +13,10 @@ import dynamic from "next/dynamic";
 import AboutSection from "./AboutSection";
 import { useHeroState } from "../../contexts/HeroStateContext";
 
-const MissionContent = dynamic(() => import("./MissionContent"), {
-	ssr: false,
-});
+// ssr:false にしない。MISSIONの本文（事業説明の中核）は SEO 上 HTML に存在する必要がある。
+// ssr:false だと初期HTMLに一切出力されず、Google のレンダリング待ちに依存してしまう。
+// コード分割は dynamic のまま維持しているので、チャンクは分かれる。
+const MissionContent = dynamic(() => import("./MissionContent"));
 
 // お問い合わせフォームと Toaster を遅延読み込みする。
 // これにより zod / react-hook-form / radix / sonner がトップの初期バンドルから外れる。


### PR DESCRIPTION
## 概要

MISSIONセクションの本文（事業説明の中核）が初期HTMLに一切出力されていなかった問題の修正。URL設計のレビュー中に発見した、ハッシュの話より遥かに重要な実害。

## 問題

`MissionContent` が `dynamic(ssr:false)` のため、以下のテキストがビルド出力のHTMLに存在しなかった。

- 「ビジネスの課題に、技術と対話で向き合います。」
- 「外部の制作会社ではなく、チームの一員として。」
- 「つくる人、使う人、続ける事業のために。」

GoogleはJSを実行するため「インデックスされない」と断定はできないが、レンダリング待ち・失敗・JS非対応クローラを考えるとSSRより確実に不利。

## 変更

`ssr: false` のみを削除（1行）。`dynamic` によるコード分割は維持。

## 検証

- **初期HTMLに3項目とも出力されることを確認**（デスクトップ版・モバイル版を両方レンダリングしCSSで出し分ける構造のため各2箇所）
- コンソールエラー0件、ハイドレーション不整合なし
- pnpm lint / tsc エラー0件

### パフォーマンス実測（トップページ）

| 計測方式 | 指標 | 変更前 | 変更後 |
|---|---|---|---|
| 実スロットリング | スコア | 91 | 92 |
| | FCP / LCP | 1.6s / 1.6s | 1.6s / 1.6s |
| | TBT | 80 ms | 90 ms |
| シミュレーション | スコア | 97 | 98 |
| | FCP / LCP | 0.8s / 2.3s | 0.8s / 2.2s |
| | TBT | 80 ms | 80 ms |

メインスレッド総時間は 2.2s → 3.4s に増えるが、TBT（ブロッキング時間）は +10ms に留まり体感への影響はない。

## 既知の制約

本文は `useTransform` による `opacity: 0` の状態でHTMLに入る（スクロール連動で現れる演出のため）。HTMLに存在しない現状よりは確実に良いが、完全に可視のテキストより重みが落ちる可能性は残る。完全解決するには本文の静的コンポーネントと演出レイヤーの分離が必要で、それは別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n