### PR TITLE
fix(nav): セクション遷移でURLを更新し戻る/進むに対応、id="contact" を追加

### DIFF
--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -1,7 +1,7 @@
 // src/app/components/HomeClient.tsx
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import dynamic from "next/dynamic";
 import MissionSection, { type MissionSidebarHandle } from "./MissionSection";
 
@@ -56,7 +56,20 @@ export default function HomeClient() {
 		return () => window.removeEventListener("resize", checkMobile);
 	}, []);
 
+	// 経路3: トップページ上でのナビクリック。
+	// 到達処理（スムーズスクロール）は従来どおりで、URLの更新だけを足す。
+	// これまでURLを一切変えていなかったため、共有もブックマークも戻るボタンも効かなかった。
+	// popstate 側で navigateToHash を呼ぶので、戻る/進むでも位置が追従する。
 	const handleNavigate = (path: string) => {
+		// URLを履歴に積む。トップ(/)はハッシュを外す
+		const hash = path === "/" ? "" : `#${path.replace(/^\//, "")}`;
+		if (hash === "" || HASH_TARGETS.includes(hash)) {
+			const nextUrl = hash === "" ? window.location.pathname : hash;
+			if (window.location.hash !== hash) {
+				window.history.pushState(null, "", nextUrl);
+			}
+		}
+
 		if (path === "/about") {
 			// AboutセクションはMissionSectionの中にあるため、
 			// まずはメインのスクロールをMissionSectionが表示される位置（＝一番下）まで持っていく
@@ -118,37 +131,34 @@ export default function HomeClient() {
 		}
 	};
 
-	// 他ページ（LPのCTAやグローバルナビなど）から `/#contact` `/#mission` `/#about` で
-	// アクセスされた場合、該当セクションへ直行する。
+	// セクションへの到達処理をここ1箇所に集約する。
 	// トップは1000vhのスクロール演出ページで、セクションの表示はスクロール量に紐づくため、
 	// ブラウザ標準のアンカージャンプでは演出の状態が追いつかず到達できない。
 	// smoothスクロールも1000vh分の移動が不安定なため、スナップ方式で瞬時に移動する。
-	// biome-ignore lint/correctness/useExhaustiveDependencies: 初回マウント時のみ実行したいため依存に含めない
-	useEffect(() => {
-		const hash = window.location.hash;
-		if (!HASH_TARGETS.includes(hash)) return;
-		// フラグは1回のジャンプで使い切る（残すと直接アクセス時のhydrationに影響しうる）
-		sessionStorage.removeItem(HASH_JUMP_FLAG);
+	//
+	// pushState/replaceState は hashchange も popstate も発火しないため、
+	// 「クリック」「初回ロード」「戻る/進む(popstate)」の全経路からこの関数を呼ぶ必要がある。
+	const navigateToHash = useCallback(
+		(hash: string, options?: { withCover?: boolean }) => {
+			if (!HASH_TARGETS.includes(hash)) return;
 
-		let cancelled = false;
+			if (options?.withCover) {
+				setHashCover("solid");
+			}
 
-		// スナップ完了後、カバーをフェードで開いて片付ける
-		const revealAfterSnap = () => {
-			if (cancelled) return;
-			setShouldSnapAnimation(false);
-			setHashCover((prev) => (prev === "solid" ? "fading" : prev));
-			setTimeout(() => {
-				if (!cancelled) setHashCover("none");
-			}, 350);
-		};
+			// スナップ完了後、カバーが出ていればフェードで開いて片付ける
+			const revealAfterSnap = () => {
+				setShouldSnapAnimation(false);
+				setHashCover((prev) => (prev === "solid" ? "fading" : prev));
+				setTimeout(() => {
+					setHashCover((prev) => (prev === "fading" ? "none" : prev));
+				}, 350);
+			};
 
-		const jumpToSection = () => {
-			if (cancelled) return;
 			setIsCircleFullyExpanded(true);
 			setShouldSnapAnimation(true);
 
 			if (hash === "#mission") {
-				// handleNavigate("/mission") と同じ位置（スクロール可能域の終端手前）へスナップ
 				const docHeight =
 					document.documentElement.scrollHeight - window.innerHeight;
 				window.scrollTo({ top: docHeight * 0.999, behavior: "auto" });
@@ -163,7 +173,6 @@ export default function HomeClient() {
 			});
 			// MissionSectionが展開レンダリングされた後でないと内部スクロールが空振りするため遅延
 			setTimeout(() => {
-				if (cancelled) return;
 				if (hash === "#about") {
 					missionRef.current?.scrollToAbout();
 				} else {
@@ -171,16 +180,38 @@ export default function HomeClient() {
 				}
 				revealAfterSnap();
 			}, 300);
-		};
+		},
+		[setShouldSnapAnimation],
+	);
 
-		// 150ms はレイアウト確定を待つ最小限のマージン。
-		// 以前は 500ms だったが、カバーで中間状態を隠す前提なら長く待つ理由がない
-		const timer = setTimeout(jumpToSection, 150);
-		return () => {
-			cancelled = true;
-			clearTimeout(timer);
-		};
+	// 経路1: 初回ロード。他ページ（LPのCTAやグローバルナビ）から /#contact 等で来た場合
+	// biome-ignore lint/correctness/useExhaustiveDependencies: 初回マウント時のみ実行したいため依存に含めない
+	useEffect(() => {
+		const hash = window.location.hash;
+		if (!HASH_TARGETS.includes(hash)) return;
+		// フラグは1回のジャンプで使い切る（残すと直接アクセス時のhydrationに影響しうる）
+		sessionStorage.removeItem(HASH_JUMP_FLAG);
+
+		// 150ms はレイアウト確定を待つ最小限のマージン
+		const timer = setTimeout(() => navigateToHash(hash), 150);
+		return () => clearTimeout(timer);
 	}, []);
+
+	// 経路2: ブラウザの戻る/進む。pushStateで積んだ履歴を辿ったとき、
+	// これが無いとURLだけ変わって表示位置が追従しない
+	useEffect(() => {
+		const handlePopState = () => {
+			const hash = window.location.hash;
+			if (HASH_TARGETS.includes(hash)) {
+				navigateToHash(hash);
+			} else {
+				// ハッシュ無しの履歴項目（トップ）へ戻ったとき
+				window.scrollTo({ top: 0, behavior: "auto" });
+			}
+		};
+		window.addEventListener("popstate", handlePopState);
+		return () => window.removeEventListener("popstate", handlePopState);
+	}, [navigateToHash]);
 
 	// 黒い円の開始タイミング（hero-canvas.tsxのCIRCLE_SCROLL_STARTと同期）
 	const CIRCLE_START = 0.92;

--- a/src/app/components/MissionSection.tsx
+++ b/src/app/components/MissionSection.tsx
@@ -751,9 +751,14 @@ function MissionSection(
 				<AboutSection transitionProgress={irisTransitionProgress} />
 			</div>
 
+			{/* id="contact" は /#contact（LPのCTA・グローバルナビ・llms.txt が配布するURL）の着地点。
+			    これまで id が無く、到達は完全にJS依存だった。JS無効時・ページ内検索・支援技術のために付与する。
+			    tabIndex={-1} はプログラム的なフォーカス移動を可能にするため（キーボード操作の順序は変えない） */}
 			<div
+				id="contact"
 				ref={contactRef}
-				className={`w-full flex items-center justify-center relative z-30 ${
+				tabIndex={-1}
+				className={`w-full flex items-center justify-center relative z-30 outline-none ${
 					isMobile ? "h-[50vh]" : "h-[50vh]"
 				}`}
 			>


### PR DESCRIPTION
## 問題

1. **トップページ上でナビをクリックしてもURLが一切変わらなかった** — `onNavigate` が `preventDefault()` してプログラム的にスクロールするだけだったため、共有もブックマークも戻るボタンも効かない状態だった
2. **`/#contact` を配布しているのに `id="contact"` が存在しなかった** — LPのCTA・グローバルナビ・`llms.txt` がこのURLを指しているのに、到達が完全にJS依存でJS無効時・ページ内検索・支援技術で機能しなかった

## 変更

- **到達処理を `navigateToHash` に集約**。`pushState` / `replaceState` は `hashchange` も `popstate` も発火しないため、「初回ロード」「戻る/進む」「クリック」の全経路から同じ関数を呼ぶ必要がある
- **`popstate` ハンドラを追加**。これが無いと `pushState` で積んだ履歴を辿ったときにURLだけ変わって表示位置が追従しない
- **ナビクリック時に `pushState` でURLを更新**。到達処理（スムーズスクロール）は従来どおりで、URL更新だけを足した
- **`id="contact"` を CONTACT セクションに付与**。`tabIndex={-1}` も付けてプログラム的なフォーカス移動を可能にした（キーボード操作の順序は変えない）

## 意図的に採用しなかった案

当初案の「ユーザーが任意スクロールしたらハッシュを消す」は**撤回した**。`replaceState` で履歴項目を書き換えると戻る先の意味が壊れるうえ、慣性・自動スナップ・内部スクロールがあるため閾値判定も信頼できないため（codex レビューでも同じ指摘）。

ハッシュが残るのは不具合ではなく、共有可能な到達位置を示す正常な状態。URLをスクロール位置に追従させる scroll-spy は、この三重スクロール構造ではリスクとコストが効果に見合わないと判断した。

## SEOについて

URLフラグメントは別URLとしてインデックスされないため、**これはSEO施策ではなくUX・履歴・共有性・アクセシビリティの改善**である。

## 検証

- pnpm lint / tsc エラー0件
- ビルド出力に `id="contact"` `id="mission"` `id="about"` の3つが揃うことを確認
- **ユーザーが実機確認済み**: ナビクリックでのURL更新、戻るボタン3回でURLと表示位置が一緒に戻ること、LPからの遷移の回帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n