### PR TITLE
fix(seo): AIクローラの指定を現行の名称に更新しCrawl-delayを削除

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,27 +4,68 @@
 User-agent: *
 Allow: /
 
-# AI Crawlers (AIO対応)
+# ------------------------------------------------------------------
+# AI クローラ（AIO対応）
+# 事業方針として、AI検索・AIアシスタントから見つけてもらうことを狙うため
+# 学習用・検索用・ユーザー起点アクセスのいずれも明示的に許可する。
+# 名称は各社が変更するため、更新時は必ず公式ドキュメントで確認すること:
+#   OpenAI    https://developers.openai.com/api/docs/bots
+#   Anthropic https://support.claude.com/en/articles/8896518
+# ------------------------------------------------------------------
+
+# --- OpenAI / ChatGPT ---
+# 検索結果への掲載（ChatGPTのsearch機能）
+User-agent: OAI-SearchBot
+Allow: /
+
+# 基盤モデルの学習
 User-agent: GPTBot
 Allow: /
 
-User-agent: Claude-Web
+# ユーザーがChatGPT上でページを開いたとき
+User-agent: ChatGPT-User
 Allow: /
 
+# --- Anthropic / Claude ---
+# 検索結果の品質向上（Claudeの検索）
+User-agent: Claude-SearchBot
+Allow: /
+
+# 生成AIモデルの学習
+User-agent: ClaudeBot
+Allow: /
+
+# ユーザーがClaudeに質問した際のアクセス
+User-agent: Claude-User
+Allow: /
+
+# --- Perplexity ---
 User-agent: PerplexityBot
 Allow: /
 
-User-agent: Anthropic-AI
+User-agent: Perplexity-User
 Allow: /
 
+# --- Google (Gemini / AI Overviews 向けの利用可否制御) ---
 User-agent: Google-Extended
 Allow: /
 
-# llms.txtへの参照 (AIOプロトコル準拠)
+# --- Apple Intelligence ---
+User-agent: Applebot-Extended
+Allow: /
+
+# --- Common Crawl（多くのLLMが学習データ源として利用）---
+User-agent: CCBot
+Allow: /
+
+# --- Microsoft Copilot ---
+User-agent: bingbot
+Allow: /
+
+# ------------------------------------------------------------------
+# AI向けのサイト説明
 # https://tanebi-net.com/llms.txt
+# ------------------------------------------------------------------
 
 # サイトマップ
 Sitemap: https://tanebi-net.com/sitemap.xml
-
-# クロール遅延
-Crawl-delay: 1


### PR DESCRIPTION
## 問題

`robots.txt` に書かれていた `Claude-Web` / `anthropic-ai` は、**現行の公式ドキュメントに存在しない古い名称**だった。結果として **Claude の検索クローラ（`Claude-SearchBot`）が明示的に許可されていない**状態になっていた。

`User-agent: *` の `Allow: /` があるため実質的なブロックはされていないが、AI検索からの流入を事業方針に据えている以上、意図が伝わる形にすべきと判断。

## 変更

各社の公式ドキュメントで確認したうえで、**学習用・検索用・ユーザー起点**の3種類をそれぞれ明示した。

| 提供元 | 検索 | 学習 | ユーザー起点 |
|---|---|---|---|
| OpenAI | `OAI-SearchBot` | `GPTBot` | `ChatGPT-User` |
| Anthropic | `Claude-SearchBot` | `ClaudeBot` | `Claude-User` |
| Perplexity | `PerplexityBot` | — | `Perplexity-User` |

その他: `Google-Extended` / `Applebot-Extended` / `CCBot` / `bingbot`

出典（ファイル内のコメントにも記載）:
- https://developers.openai.com/api/docs/bots
- https://support.claude.com/en/articles/8896518

## `Crawl-delay: 1` の削除

Googlebot は `Crawl-delay` を無視するが一部のクローラは従うため、AI検索に載せたいという方針と矛盾していた。Vercel の CDN で配信される小規模な静的サイトでレート制限の必要もないため削除。

## 補足：この変更の位置づけ

AI系クローラは基本的にJSを実行せず生のHTMLを読む。そのため PR #178（MissionContent の SSR化）が AI検索の可視性には最も効いており、本PRはその前提となる「読みに来られる状態」を整えるもの。

## 検証

- 9つのクローラ指定がすべて出力されること、`Disallow` が無いこと、`Crawl-delay` が消えたこと、`Sitemap` が残っていることをスクリプトで確認
- pnpm lint / build エラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n