### PR TITLE
chore(lp): /service と /service/issues をコピー刷新まで非公開にする

### DIFF
--- a/src/app/service/issues/page.tsx
+++ b/src/app/service/issues/page.tsx
@@ -20,6 +20,10 @@ export const metadata: Metadata = {
 	title: "その課題、ここから伸ばせます | TANEBI CREATIVE",
 	description:
 		"ホームページを作って終わりにしない改善、ネット販売の立て直し、社内業務のツール化、増えすぎたツール費用の見直し、社内でAIを使える状態にすること。「こうしたい」から一緒に進めます。初回相談は無料です。",
+	// 事業ポジショニングの見直しに伴いコピーを刷新中のため、確定するまで検索エンジンには載せない。
+	// パフォーマンス改善を先に本番へ出すための一時措置。
+	// 正式公開時にこの robots を削除し、sitemap.ts と showcase-cards.ts のリンクも戻すこと。
+	robots: { index: false, follow: false },
 };
 
 /** menuLabel / menuHref は /service の該当メニューへの送り先。見出しの文言も向こうに揃える */

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -18,6 +18,10 @@ export const metadata: Metadata = {
 	title: "できること ─ ご相談メニュー | TANEBI CREATIVE",
 	description:
 		"問い合わせを取りこぼさないWebサイトの制作・改善、AI活用の相談、業務ツールの開発。受け取ったあとの社内の流れまで含めて設計します。どれも「まず話を聞いてから」始められます。初回相談は無料です。",
+	// 事業ポジショニングの見直しに伴いコピーを刷新中のため、確定するまで検索エンジンには載せない。
+	// パフォーマンス改善を先に本番へ出すための一時措置。
+	// 正式公開時にこの robots を削除し、sitemap.ts と showcase-cards.ts のリンクも戻すこと。
+	robots: { index: false, follow: false },
 };
 
 type Menu = {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,18 +12,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			changeFrequency: "weekly",
 			priority: 1,
 		},
-		{
-			url: `${SITE_URL}/service`,
-			lastModified: new Date(),
-			changeFrequency: "monthly",
-			priority: 0.8,
-		},
-		{
-			url: `${SITE_URL}/service/issues`,
-			lastModified: new Date(),
-			changeFrequency: "monthly",
-			priority: 0.8,
-		},
+		// /service と /service/issues は事業ポジショニングの見直しに伴いコピーを刷新中のため、
+		// 確定するまで noindex にしている（各ページの metadata.robots を参照）。
+		// noindex のページを sitemap に載せると Search Console で警告になるため、あわせて除外する。
+		// 正式公開時に下記を復活させること:
+		//   { url: `${SITE_URL}/service`,        lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
+		//   { url: `${SITE_URL}/service/issues`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
 	];
 
 	// 動的ページ（ブログ記事）

--- a/src/components/three/showcase-cards.ts
+++ b/src/components/three/showcase-cards.ts
@@ -10,7 +10,8 @@ export const SHOWCASE_CARDS: VideoSlide[] = [
 		description:
 			"作って終わりのホームページ、伸びないネット販売、社内の手間、AIの使いどころ。「こうしたい」から一緒に進めます。",
 		category: "サービス",
-		liveUrl: "/service/issues",
+		// コピー刷新中のためリンクは一時的に外している（/service/issues 本体は残置・noindex）
+		// 正式公開時に liveUrl: "/service/issues" を戻すこと
 	},
 	{
 		id: "service-menu",
@@ -20,7 +21,8 @@ export const SHOWCASE_CARDS: VideoSlide[] = [
 		description:
 			"Webサイトの制作・改善、AI活用の相談、業務ツールの開発。どれも「まず話を聞いてから」始めます。",
 		category: "サービス",
-		liveUrl: "/service",
+		// コピー刷新中のためリンクは一時的に外している（/service 本体は残置・noindex）
+		// 正式公開時に liveUrl: "/service" を戻すこと
 	},
 	{
 		id: "works-internal-tool",

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -10,8 +10,7 @@ import {
 	Rocket,
 	User,
 	Bird,
-	Wrench,
-	Lightbulb,
+	// Wrench / Lightbulb は SERVICE / ISSUES をナビに戻すときに再度使う
 } from "lucide-react";
 import gsap from "gsap";
 
@@ -39,20 +38,13 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 	// href はハッシュ形式にしておくことで、LP等の別ページから開いたときも
 	// 通常のリンクとして /#hash 経由でトップの該当セクションへ飛べるようにする。
 	// トップページ上での挙動（スムーズスクロール）は onClick 側で別途インターセプトする。
+	// SERVICE / ISSUES は事業ポジショニングの見直しに伴いコピーを刷新中のため、
+	// 確定するまでナビから外している（ページ本体は残置・noindex）。
+	// 正式公開時に下記を TOP の直後に戻すこと:
+	//   { href: "/service",        label: "SERVICE", icon: Wrench,    description: "できること・ご相談メニュー" },
+	//   { href: "/service/issues", label: "ISSUES",  icon: Lightbulb, description: "その課題、ここから伸ばせます" },
 	const menuItems = [
 		{ href: "/", label: "TOP", icon: Home, description: "トップページ" },
-		{
-			href: "/service",
-			label: "SERVICE",
-			icon: Wrench,
-			description: "できること・ご相談メニュー",
-		},
-		{
-			href: "/service/issues",
-			label: "ISSUES",
-			icon: Lightbulb,
-			description: "その課題、ここから伸ばせます",
-		},
 		{
 			href: "/#mission",
 			label: "MISSION",


### PR DESCRIPTION
## 目的

事業ポジショニングの見直し（制作中心 → 改善・仕組みづくり中心）に伴い LP のコピーを刷新することになった。確定するまで検索エンジンとサイト内導線から外し、**パフォーマンス改善だけを先に本番へ出せるようにする**。

本番は現在 Lighthouse スコア46 / LCP 20.2秒のままで、コピーの意思決定を待つ間ずっと訪問者がその状態を踏み続ける。技術的改善を戦略決定の人質にしないための一時措置。

## 変更

| 対象 | 内容 |
|---|---|
| `service/page.tsx` / `service/issues/page.tsx` | `robots: { index:false, follow:false }` を追加（`/works` が同じ理由で既に採用している形に揃えた） |
| `sitemap.ts` | 2ページを除外（noindex のページを sitemap に載せると Search Console の警告になる） |
| `showcase-cards.ts` | トップの3D回転カードから `liveUrl` を除去（`/works` と同じ扱い） |
| `sidebar-menu.tsx` | グローバルナビから SERVICE / ISSUES を除去 |

ページ本体は残置しているため、URL直打ちと Vercel プレビューでは引き続き確認できる。

## 正式公開時に戻す箇所

各ファイルのコメントに明記済み。

- `src/app/service/page.tsx` — `robots` を削除
- `src/app/service/issues/page.tsx` — `robots` を削除
- `src/app/sitemap.ts` — コメントアウトした2エントリを復活
- `src/components/three/showcase-cards.ts` — `liveUrl` を2箇所復活
- `src/components/ui/sidebar-menu.tsx` — メニュー項目2件と `Wrench` / `Lightbulb` の import を復活

## 検証

ビルド出力に対して確認済み。

- `/service` `/service/issues` `/works` の3ページとも `noindex`
- sitemap から2ページが除外されている
- トップページから `/service` へのリンクが **0件**
- pnpm lint / tsc エラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n