### PR TITLE
fix(top): 3D回転カードをmicroCMS記事ベースの実装に戻す

### DIFF
--- a/src/components/three/HeroCanvasSection.tsx
+++ b/src/components/three/HeroCanvasSection.tsx
@@ -1,19 +1,76 @@
 import type { ReactNode } from "react";
 import { HeroStateProvider } from "../../contexts/HeroStateProvider";
+import { type BlogPost, getBlogPosts } from "../../lib/microcms";
 import HeroCanvasWrapper from "./HeroCanvasWrapper";
-import { SHOWCASE_CARDS } from "./showcase-cards";
+
+// BlogPostを3D回転カード用のデータに変換する
+function blogPostToVideoSlide(post: BlogPost) {
+	// mediaTypeが配列で返る場合があるため先頭を取る
+	let mediaType = post.mediaType || "image";
+	if (Array.isArray(mediaType)) {
+		mediaType = mediaType[0] || "image";
+	}
+
+	return {
+		id: post.id,
+		title: post.title,
+		mediaType: mediaType as "image" | "video",
+		mp4: mediaType === "video" ? post.videoUrl : undefined,
+		imageSrc: mediaType === "image" ? post.eyecatch?.url : undefined,
+		description: post.content
+			? post.content.replace(/<[^>]*>/g, "").substring(0, 100)
+			: "",
+		publishedAt: post.publishedAt,
+		category: Array.isArray(post.category)
+			? // biome-ignore lint/suspicious/noExplicitAny: microCMSのcategoryは文字列/オブジェクトの両方が来る
+				(post.category[0] as any)?.name || post.category[0]
+			: // biome-ignore lint/suspicious/noExplicitAny: 同上
+				(post.category as any)?.name || post.category,
+		liveUrl: `/blog/${post.id}`,
+	};
+}
 
 interface HeroCanvasSectionProps {
 	children: ReactNode;
 }
 
-export default function HeroCanvasSection({
+/**
+ * トップページの3D回転カードを microCMS のブログ記事から生成する。
+ *
+ * 一時期 showcase-cards.ts の固定値（サービス紹介3枚）に置き換えていたが、
+ * LPのコピー刷新に伴い /service 系を非公開にした結果、リンク先を持たないカードが
+ * 並ぶ状態になったため、記事ベースの実装に戻した。
+ * 取得に失敗した場合は videoSlides を undefined にして、
+ * HeroCanvas 側のフォールバック（getSafeVideoSlides）に委ねる。
+ */
+export default async function HeroCanvasSection({
 	children,
 }: HeroCanvasSectionProps) {
+	let videoSlides: ReturnType<typeof blogPostToVideoSlide>[] = [];
+
+	try {
+		const response = await getBlogPosts(20, 0);
+		// isShowcase を持つ記事だけを出す。フィールド自体が無い場合は全記事を対象にする
+		const showcasePosts = response.contents.filter((post) =>
+			post.isShowcase !== undefined ? post.isShowcase : true,
+		);
+
+		if (showcasePosts.length > 0) {
+			videoSlides = showcasePosts.map(blogPostToVideoSlide);
+		}
+	} catch (error) {
+		console.warn(
+			"microCMSからの記事取得に失敗、フォールバックデータを使用:",
+			error instanceof Error ? error.message : error,
+		);
+	}
+
 	return (
 		<HeroStateProvider>
 			{/* 3D Scene (Client Side Only via Dynamic Import with ssr: false) */}
-			<HeroCanvasWrapper videoSlides={SHOWCASE_CARDS} />
+			<HeroCanvasWrapper
+				videoSlides={videoSlides.length > 0 ? videoSlides : undefined}
+			/>
 
 			{/* Main Content (SSR Safe) - Rendered independently of 3D Canvas */}
 			<div

--- a/src/components/three/showcase-cards.ts
+++ b/src/components/three/showcase-cards.ts
@@ -1,6 +1,13 @@
 import type { VideoSlide } from "../../types/content";
 
-// トップの3D回転カード。CMSではなくコードで管理する。
+// トップの3D回転カードをサービス紹介に差し替えるための定数。
+//
+// 【現在このファイルは使われていない】
+// LPのコピー刷新に伴い /service 系を非公開にした結果、リンク先を持たないカードが
+// 並ぶ状態になったため、HeroCanvasSection は microCMS のブログ記事から
+// カードを生成する実装に戻してある。
+// LPを正式公開する際、カードをサービス紹介に戻すならこの定数を再利用できる
+// （その場合は liveUrl のコメントアウトも解除すること）。
 export const SHOWCASE_CARDS: VideoSlide[] = [
 	{
 		id: "service-issues",


### PR DESCRIPTION
## 問題

LPのコピー刷新に伴い `/service` `/service/issues` を非公開にした際（PR #181）、トップの3D回転カードから `liveUrl` を除去した。その結果、**カード3枚すべてがリンク先を持たない状態**になり、クリックしても何も起きないカードが並んでいた。

カードをサービス紹介の固定値に置き換えたのは `feature/service-lp-pages` の `1a2e287`（2026-07）で、それ以前の本番は microCMS のブログ記事からカードを生成していた。今回 dev を main にマージしたことで固定値版が初めて本番に出たが、LP非公開と組み合わさって破綻した形になった。

## 対応

`HeroCanvasSection` を microCMS 記事ベースの実装に戻した（旧 `HeroCanvasWithCMS.tsx` と同じロジック。ファイル名は現行のまま維持して差分を最小化）。

- `isShowcase` を持つ記事のみをカード化。フィールドが無い場合は全記事を対象
- 取得失敗時は `videoSlides` を undefined にして `hero-canvas` 側の `getSafeVideoSlides` によるフォールバックに委ねる

`showcase-cards.ts` はコードから参照されなくなったが、LP正式公開時にカードをサービス紹介へ戻す選択肢を残すため削除せず、使われていない旨をコメントに明記した。

## 検証

- pnpm lint / tsc エラー0件
- microCMS取得失敗時にフォールバック4枚（「デジタルの悩みをシンプルに」等）が出ることを確認。ローカルはAPIキーが401のため、この経路が実際に通ることを確認できた
- 本番の Vercel には有効なキーがあり、記事2件が sitemap に出力されていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n