### PR TITLE
fix(top): 3D回転カードをmicroCMS記事ベースに戻す

### DIFF
--- a/src/components/three/HeroCanvasSection.tsx
+++ b/src/components/three/HeroCanvasSection.tsx
@@ -1,19 +1,76 @@
 import type { ReactNode } from "react";
 import { HeroStateProvider } from "../../contexts/HeroStateProvider";
+import { type BlogPost, getBlogPosts } from "../../lib/microcms";
 import HeroCanvasWrapper from "./HeroCanvasWrapper";
-import { SHOWCASE_CARDS } from "./showcase-cards";
+
+// BlogPostを3D回転カード用のデータに変換する
+function blogPostToVideoSlide(post: BlogPost) {
+	// mediaTypeが配列で返る場合があるため先頭を取る
+	let mediaType = post.mediaType || "image";
+	if (Array.isArray(mediaType)) {
+		mediaType = mediaType[0] || "image";
+	}
+
+	return {
+		id: post.id,
+		title: post.title,
+		mediaType: mediaType as "image" | "video",
+		mp4: mediaType === "video" ? post.videoUrl : undefined,
+		imageSrc: mediaType === "image" ? post.eyecatch?.url : undefined,
+		description: post.content
+			? post.content.replace(/<[^>]*>/g, "").substring(0, 100)
+			: "",
+		publishedAt: post.publishedAt,
+		category: Array.isArray(post.category)
+			? // biome-ignore lint/suspicious/noExplicitAny: microCMSのcategoryは文字列/オブジェクトの両方が来る
+				(post.category[0] as any)?.name || post.category[0]
+			: // biome-ignore lint/suspicious/noExplicitAny: 同上
+				(post.category as any)?.name || post.category,
+		liveUrl: `/blog/${post.id}`,
+	};
+}
 
 interface HeroCanvasSectionProps {
 	children: ReactNode;
 }
 
-export default function HeroCanvasSection({
+/**
+ * トップページの3D回転カードを microCMS のブログ記事から生成する。
+ *
+ * 一時期 showcase-cards.ts の固定値（サービス紹介3枚）に置き換えていたが、
+ * LPのコピー刷新に伴い /service 系を非公開にした結果、リンク先を持たないカードが
+ * 並ぶ状態になったため、記事ベースの実装に戻した。
+ * 取得に失敗した場合は videoSlides を undefined にして、
+ * HeroCanvas 側のフォールバック（getSafeVideoSlides）に委ねる。
+ */
+export default async function HeroCanvasSection({
 	children,
 }: HeroCanvasSectionProps) {
+	let videoSlides: ReturnType<typeof blogPostToVideoSlide>[] = [];
+
+	try {
+		const response = await getBlogPosts(20, 0);
+		// isShowcase を持つ記事だけを出す。フィールド自体が無い場合は全記事を対象にする
+		const showcasePosts = response.contents.filter((post) =>
+			post.isShowcase !== undefined ? post.isShowcase : true,
+		);
+
+		if (showcasePosts.length > 0) {
+			videoSlides = showcasePosts.map(blogPostToVideoSlide);
+		}
+	} catch (error) {
+		console.warn(
+			"microCMSからの記事取得に失敗、フォールバックデータを使用:",
+			error instanceof Error ? error.message : error,
+		);
+	}
+
 	return (
 		<HeroStateProvider>
 			{/* 3D Scene (Client Side Only via Dynamic Import with ssr: false) */}
-			<HeroCanvasWrapper videoSlides={SHOWCASE_CARDS} />
+			<HeroCanvasWrapper
+				videoSlides={videoSlides.length > 0 ? videoSlides : undefined}
+			/>
 
 			{/* Main Content (SSR Safe) - Rendered independently of 3D Canvas */}
 			<div

--- a/src/components/three/showcase-cards.ts
+++ b/src/components/three/showcase-cards.ts
@@ -1,6 +1,13 @@
 import type { VideoSlide } from "../../types/content";
 
-// トップの3D回転カード。CMSではなくコードで管理する。
+// トップの3D回転カードをサービス紹介に差し替えるための定数。
+//
+// 【現在このファイルは使われていない】
+// LPのコピー刷新に伴い /service 系を非公開にした結果、リンク先を持たないカードが
+// 並ぶ状態になったため、HeroCanvasSection は microCMS のブログ記事から
+// カードを生成する実装に戻してある。
+// LPを正式公開する際、カードをサービス紹介に戻すならこの定数を再利用できる
+// （その場合は liveUrl のコメントアウトも解除すること）。
 export const SHOWCASE_CARDS: VideoSlide[] = [
 	{
 		id: "service-issues",


### PR DESCRIPTION
## 概要

前回のリリース（PR #182）で発生した、トップの3D回転カードがリンク先を持たない状態になる問題の修正。

## 問題

PR #182 で以下2つの変更が同時に本番へ出たことで破綻していた。

1. カードを microCMS 記事から**コード内の固定値（サービス紹介3枚）に変更**（`feature/service-lp-pages` の `1a2e287`、2026-07）
2. LPのコピー刷新に伴い `/service` `/service/issues` を非公開にし、**カードから `liveUrl` を除去**（PR #181）

1だけなら「サービス紹介カードがLPにリンクする」で成立し、2だけなら影響しなかったが、両方が重なった結果**クリックしても何も起きないカードが3枚並ぶ状態**になった。

## 対応

`HeroCanvasSection` を microCMS 記事ベースの実装に戻した（リリース前の本番と同じ挙動）。`showcase-cards.ts` は LP 正式公開時に再利用できるよう残し、現在未使用である旨をコメントに明記。

## このリリース後の状態

- **パフォーマンス改善版**（スコア46→74、LCP 20.2s→4.5s、総転送量 3.99MB→1.79MB）
- **3D回転カードはブログ記事ベース**（リリース前の本番と同じ）
- **`/service` `/service/issues` `/works` は非公開**（noindex + sitemap除外 + サイト内導線なし）

## 検証

- ビルド出力で LP3ページの noindex、sitemap からの除外、トップからのリンク0件を確認
- Vercel プレビューでカード表示をユーザーが実機確認済み
- CI（lint / build / Vercel）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n