### PR TITLE
fix(nav): ハッシュ遷移でCONTACTに着地せずMISSIONに戻る不具合を修正

### DIFF
--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -11,13 +11,18 @@ const SidebarMenu = dynamic(
 );
 import ContactSection from "./ContactSection";
 import { useHeroState } from "@/contexts/HeroStateContext";
+import { HASH_JUMP_FLAG } from "@/lib/hash-jump";
 
-// ハッシュ付きでトップに遷移してきたとき、スナップ完了までの中間状態を隠すためのフラグ。
-// sidebar-menu.tsx が LP 等でのクリック時に sessionStorage に立て、ここで消費する。
-// sessionStorage を経由するのは、SSR/直接アクセス時の hydration とずらすため
-// （直接アクセスはクリックを経ないのでフラグが無く、LoadingScreen が代わりに覆う）。
-export const HASH_JUMP_FLAG = "tanebi:hash-jump";
 const HASH_TARGETS: readonly string[] = ["#mission", "#about", "#contact"];
+
+// #mission の着地点。スクロール量の 0.999 相当（MissionSection の SECTION_END と対応）
+const MISSION_SCROLL_RATIO = 0.999;
+
+// 着地してから黒カバーを開けるまでの待ち。
+// 着地自体は瞬時に終わるが、動的インポートが直後に解決するとコンテンツが伸びて
+// 位置がわずかに動く。MissionSection 側の再アンカーが直すので破綻はしないが、
+// その調整が視界に入らないよう少しだけ引っ張る。
+const REVEAL_DELAY_MS = 250;
 
 export default function HomeClient() {
 	// Optimization: Removed scrollProgress state to prevent re-renders
@@ -56,80 +61,21 @@ export default function HomeClient() {
 		return () => window.removeEventListener("resize", checkMobile);
 	}, []);
 
-	// 経路3: トップページ上でのナビクリック。
-	// 到達処理（スムーズスクロール）は従来どおりで、URLの更新だけを足す。
-	// これまでURLを一切変えていなかったため、共有もブックマークも戻るボタンも効かなかった。
-	// popstate 側で navigateToHash を呼ぶので、戻る/進むでも位置が追従する。
-	const handleNavigate = (path: string) => {
-		// URLを履歴に積む。トップ(/)はハッシュを外す
-		const hash = path === "/" ? "" : `#${path.replace(/^\//, "")}`;
-		if (hash === "" || HASH_TARGETS.includes(hash)) {
-			const nextUrl = hash === "" ? window.location.pathname : hash;
-			if (window.location.hash !== hash) {
-				window.history.pushState(null, "", nextUrl);
-			}
-		}
-
-		if (path === "/about") {
-			// AboutセクションはMissionSectionの中にあるため、
-			// まずはメインのスクロールをMissionSectionが表示される位置（＝一番下）まで持っていく
-			window.scrollTo({
-				top: document.documentElement.scrollHeight,
-				behavior: "smooth",
-			});
-
-			// その後、MissionSection内部でAboutまでスクロール
-			// 少し遅延させて、メインスクロールが始まった後に実行（あるいは完了後が良いが、並行でも動くはず）
-			setTimeout(() => {
-				missionRef.current?.scrollToAbout();
-			}, 500);
-		} else if (path === "/contact") {
-			window.scrollTo({
-				top: document.documentElement.scrollHeight,
-				behavior: "smooth",
-			});
-			// 遅延なしで即時実行（MissionSection側でフラグ制御による即時表示を行う）
-			missionRef.current?.scrollToContact();
-		} else if (path === "/mission") {
-			const docHeight =
-				document.documentElement.scrollHeight - window.innerHeight;
-			// MissionSectionの定数と合わせる (Mobile: 0.85, Desktop: 0.94)
-			// 少し余裕を持たせて、アニメーションが開始した直後の状態(0.15付近)にするなら
-			// Start + (End - Start) * 0.15 くらいが適切だが、
-			// シンプルにセクション開始位置(Start)へ遷移させる
-			// const SECTION_START = isMobile ? 0.85 : 0.94;
-			// 0.95進んだ位置を計算 (TECHNICAL PARTNERが完全に横に並んだ状態)
-			const SECTION_END = 0.999;
-			// New mapping adjustment:
-			// The video section is now much longer, pushing the Mission/About transition to the very end.
-			// Target near the end of the scroll range.
-			const targetScroll = docHeight * SECTION_END;
-
-			// ミッション表示に必要なフラグを強制的にONにする
-			setIsCircleFullyExpanded(true);
-
-			// ★アニメーションのスムージングを無効化（スナップ）
-			setShouldSnapAnimation(true);
-
-			window.scrollTo({
-				top: targetScroll,
-				behavior: "auto",
-			});
-
-			// 即座に実行してグレー背景などの状態をリセット
-			missionRef.current?.scrollToMission();
-
-			// 少し遅れてスナップフラグを解除
-			setTimeout(() => {
-				setShouldSnapAnimation(false);
-			}, 100);
-		} else if (path === "/") {
-			window.scrollTo({
-				top: 0,
-				behavior: "smooth",
-			});
-		}
-	};
+	// window.scrollTo({ behavior: "auto" }) の直後に必ず呼ぶ。
+	//
+	// 下の Animation Loop はスクロール量を1フレームあたり差分の8%ずつ補間して追う。
+	// そのため瞬間移動したスクロール位置に追いつくまで約43フレーム（60fpsで約717ms）かかり、
+	// その間ループは「まだ画面上部にいる」と判断して isCircleFullyExpanded を false に戻す。
+	// false になると MissionSection 側の進行度が巻き戻され、overflow-hidden が復帰して
+	// 内部スクロールが無効化されるため、セクションへの着地が丸ごと失われる。
+	// 補間の途中経過を捨てて即座に実位置と一致させることで、この巻き戻しを断つ。
+	const syncScrollLerp = useCallback(() => {
+		const docHeight =
+			document.documentElement.scrollHeight - window.innerHeight;
+		const scrolled = docHeight > 0 ? window.scrollY / docHeight : 0;
+		targetScrollRef.current = scrolled;
+		currentScrollRef.current = scrolled;
+	}, []);
 
 	// セクションへの到達処理をここ1箇所に集約する。
 	// トップは1000vhのスクロール演出ページで、セクションの表示はスクロール量に紐づくため、
@@ -161,7 +107,11 @@ export default function HomeClient() {
 			if (hash === "#mission") {
 				const docHeight =
 					document.documentElement.scrollHeight - window.innerHeight;
-				window.scrollTo({ top: docHeight * 0.999, behavior: "auto" });
+				window.scrollTo({
+					top: docHeight * MISSION_SCROLL_RATIO,
+					behavior: "auto",
+				});
+				syncScrollLerp();
 				missionRef.current?.scrollToMission();
 				setTimeout(revealAfterSnap, 100);
 				return;
@@ -171,17 +121,48 @@ export default function HomeClient() {
 				top: document.documentElement.scrollHeight,
 				behavior: "auto",
 			});
-			// MissionSectionが展開レンダリングされた後でないと内部スクロールが空振りするため遅延
-			setTimeout(() => {
-				if (hash === "#about") {
-					missionRef.current?.scrollToAbout();
-				} else {
-					missionRef.current?.scrollToContact();
-				}
-				revealAfterSnap();
-			}, 300);
+			syncScrollLerp();
+
+			// 1フレーム目でスタイル・レイアウトを確定させ、2フレーム目で offsetTop を測る。
+			// 以前はここが固定300msだったが、根拠のない待ち時間であり、
+			// 遅延読み込みの解決タイミングとも噛み合っていなかった。
+			// チャンク解決による着地点のずれは MissionSection 側の再アンカーが吸収する。
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => {
+					if (hash === "#about") {
+						missionRef.current?.scrollToAbout({ behavior: "auto" });
+					} else {
+						missionRef.current?.scrollToContact({ behavior: "auto" });
+					}
+					setTimeout(revealAfterSnap, REVEAL_DELAY_MS);
+				});
+			});
 		},
-		[setShouldSnapAnimation],
+		[setShouldSnapAnimation, syncScrollLerp],
+	);
+
+	// 経路3: トップページ上でのナビクリック。
+	// 以前はここに navigateToHash とは別の到達処理（smoothスクロール + 固定遅延）があり、
+	// 同じ目的の実装が2つ存在していた。URLの更新だけを行い、到達は navigateToHash に委ねる。
+	const handleNavigate = useCallback(
+		(path: string) => {
+			// URLを履歴に積む。トップ(/)はハッシュを外す
+			const hash = path === "/" ? "" : `#${path.replace(/^\//, "")}`;
+			if (hash !== "" && !HASH_TARGETS.includes(hash)) return;
+
+			const nextUrl = hash === "" ? window.location.pathname : hash;
+			if (window.location.hash !== hash) {
+				window.history.pushState(null, "", nextUrl);
+			}
+
+			if (hash === "") {
+				window.scrollTo({ top: 0, behavior: "smooth" });
+				return;
+			}
+
+			navigateToHash(hash);
+		},
+		[navigateToHash],
 	);
 
 	// 経路1: 初回ロード。他ページ（LPのCTAやグローバルナビ）から /#contact 等で来た場合
@@ -205,13 +186,15 @@ export default function HomeClient() {
 			if (HASH_TARGETS.includes(hash)) {
 				navigateToHash(hash);
 			} else {
-				// ハッシュ無しの履歴項目（トップ）へ戻ったとき
+				// ハッシュ無しの履歴項目（トップ）へ戻ったとき。
+				// ここでも補間を同期しないと、下に居たままの値で数百ms判定が続く
 				window.scrollTo({ top: 0, behavior: "auto" });
+				syncScrollLerp();
 			}
 		};
 		window.addEventListener("popstate", handlePopState);
 		return () => window.removeEventListener("popstate", handlePopState);
-	}, [navigateToHash]);
+	}, [navigateToHash, syncScrollLerp]);
 
 	// 黒い円の開始タイミング（hero-canvas.tsxのCIRCLE_SCROLL_STARTと同期）
 	const CIRCLE_START = 0.92;

--- a/src/app/components/MissionSection.tsx
+++ b/src/app/components/MissionSection.tsx
@@ -39,11 +39,28 @@ interface MissionSectionProps {
 	// onProgressChange?: (progress: number) => void; // Removed - avoiding parent re-renders
 }
 
-export interface MissionSidebarHandle {
-	scrollToAbout: () => void;
-	scrollToMission: () => void;
-	scrollToContact: () => void;
+export interface SectionSnapOptions {
+	/**
+	 * "smooth"（既定）= 従来のスムーズスクロール。トップページ上でのメニュー操作向け。
+	 * "auto" = 瞬時に着地。他ページからのハッシュ遷移向けで、黒カバーの下で位置を決める。
+	 */
+	behavior?: ScrollBehavior;
 }
+
+export interface MissionSidebarHandle {
+	scrollToAbout: (options?: SectionSnapOptions) => void;
+	scrollToMission: () => void;
+	scrollToContact: (options?: SectionSnapOptions) => void;
+}
+
+/**
+ * 着地直後に位置を測り直して貼り直す時間。
+ *
+ * MissionContent / ContactExperience / AboutThreeImage はいずれも動的インポートで、
+ * 他ページからのクライアント遷移ではチャンクが未取得のことがある。解決した瞬間に
+ * 上のコンテンツが伸びて着地点がずれるため、この間だけ追従させる。
+ */
+const REANCHOR_DURATION_MS = 600;
 
 // ユーティリティ
 const clamp = (v: number, min = 0, max = 1) => Math.min(max, Math.max(min, v));
@@ -78,6 +95,11 @@ function MissionSection(
 
 	// Ref to track logic state without causing re-renders
 	const showDescriptionStateRef = useRef(false);
+
+	// スナップ着地の直後、親の isCircleFullyExpanded が伝わるまで1〜2フレームの遅れが出うる。
+	// その隙に rawTarget が 0 に落ちると進行度が巻き戻り、overflow-hidden が復帰して
+	// 着地が失われるため、この時刻までは進行度の算出を続ける。
+	const holdProgressUntilRef = useRef(0);
 
 	useEffect(() => {
 		const checkMobile = () => {
@@ -126,7 +148,7 @@ function MissionSection(
 
 			// --- 1. Calculate Target based on Window Scroll ---
 			let rawTarget = 0;
-			if (isCircleFullyExpanded) {
+			if (isCircleFullyExpanded || now < holdProgressUntilRef.current) {
 				rawTarget = remap01(
 					scrollProgressRef.current,
 					SECTION_START,
@@ -291,35 +313,96 @@ function MissionSection(
 	const contactTitleRef = useRef<HTMLHeadingElement>(null);
 	const contactFormRef = useRef<HTMLDivElement>(null);
 	const backgroundRef = useRef<HTMLDivElement>(null); // 背景要素へのRef
-	const scrollPositionRef = useRef(0);
 	// 自動スクロール中かどうかを判定するフラグ
 	const isAutoScrollingToContact = useRef(false);
 	const lastScrollTopRef = useRef(0);
+	// 実行中の再アンカー処理を止めるための後始末関数
+	const reanchorCleanupRef = useRef<(() => void) | null>(null);
+
+	/**
+	 * 着地位置を REANCHOR_DURATION_MS のあいだ測り直して貼り直す。
+	 * 遅延読み込みの解決でコンテンツが伸びても着地点がずれないようにするための処理で、
+	 * ユーザーがホイール・タッチ・キー操作をしたら即座に打ち切る。
+	 */
+	const keepAnchored = useCallback((measureTop: () => number | null) => {
+		reanchorCleanupRef.current?.();
+
+		const container = containerRef.current;
+		if (!container) return;
+
+		const start = performance.now();
+		let raf = 0;
+		let stopped = false;
+
+		const stop = () => {
+			if (stopped) return;
+			stopped = true;
+			cancelAnimationFrame(raf);
+			container.removeEventListener("wheel", stop);
+			container.removeEventListener("touchstart", stop);
+			window.removeEventListener("keydown", stop);
+			reanchorCleanupRef.current = null;
+		};
+
+		const tick = () => {
+			const top = measureTop();
+			if (top !== null && Math.abs(container.scrollTop - top) > 1) {
+				container.scrollTop = top;
+			}
+			if (performance.now() - start >= REANCHOR_DURATION_MS) {
+				stop();
+				return;
+			}
+			raf = requestAnimationFrame(tick);
+		};
+
+		container.addEventListener("wheel", stop, { passive: true });
+		container.addEventListener("touchstart", stop, { passive: true });
+		window.addEventListener("keydown", stop);
+		raf = requestAnimationFrame(tick);
+		reanchorCleanupRef.current = stop;
+	}, []);
+
+	// アンマウント時に再アンカーのRAFとリスナーを確実に片付ける
+	useEffect(() => () => reanchorCleanupRef.current?.(), []);
 
 	useImperativeHandle(ref, () => ({
-		scrollToAbout: () => {
+		scrollToAbout: (options) => {
 			if (containerRef.current && aboutWrapperRef.current) {
-				// Aboutセクションの開始位置
-				const top = aboutWrapperRef.current.offsetTop;
 				// Aboutセクションのスクロール進捗0.5あたりで画像が完全に表示される
-				const wrapperHeight = aboutWrapperRef.current.clientHeight;
-				const windowHeight = window.innerHeight;
-				const targetScrollAndOffset = (wrapperHeight - windowHeight) * 0.5;
+				const measureTop = () => {
+					const wrapper = aboutWrapperRef.current;
+					if (!wrapper) return null;
+					const centeringOffset =
+						(wrapper.clientHeight - window.innerHeight) * 0.5;
+					return wrapper.offsetTop + centeringOffset;
+				};
 
-				// スムーズスクロール
-				containerRef.current.scrollTo({
-					top: top + targetScrollAndOffset,
-					behavior: "smooth",
-				});
+				const behavior = options?.behavior ?? "smooth";
+				const top = measureTop();
+				if (top !== null) {
+					containerRef.current.scrollTo({ top, behavior });
+				}
 
 				// Physicsを即座に完了させて、内部スクロール(overflow-y-auto)を有効化する
 				currentRef.current = 1.0;
 				targetRef.current = 1.0;
 				// Note: DOM updates will be picked up by RAF loop next frame
+
+				// 瞬時着地のときだけ追従させる。smooth はブラウザ側のスクロール
+				// アニメーションと競合するため行わない
+				if (behavior === "auto") {
+					holdProgressUntilRef.current =
+						performance.now() + REANCHOR_DURATION_MS;
+					keepAnchored(measureTop);
+				}
 			}
 		},
 		scrollToMission: () => {
 			if (containerRef.current) {
+				// 進行中の再アンカーがあれば止める（別セクションへ移るため）
+				reanchorCleanupRef.current?.();
+				holdProgressUntilRef.current = 0;
 				// 自動スクロールフラグを解除
 				isAutoScrollingToContact.current = false;
 
@@ -345,7 +428,7 @@ function MissionSection(
 				targetRef.current = 0.95;
 			}
 		},
-		scrollToContact: () => {
+		scrollToContact: (options) => {
 			if (containerRef.current && contactFormRef.current) {
 				// 自動スクロールフラグを立てて、即座にContact表示モードにする
 				isAutoScrollingToContact.current = true;
@@ -358,15 +441,24 @@ function MissionSection(
 				containerRef.current.classList.remove("overflow-hidden");
 				containerRef.current.classList.add("overflow-y-auto");
 
-				const top = contactFormRef.current.offsetTop;
-				containerRef.current.scrollTo({
-					top: top,
-					behavior: "smooth",
-				});
+				const measureTop = () => contactFormRef.current?.offsetTop ?? null;
+				const behavior = options?.behavior ?? "smooth";
+				const top = measureTop();
+				if (top !== null) {
+					containerRef.current.scrollTo({ top, behavior });
+				}
 
 				// Physicsを即座に完了させる
 				currentRef.current = 1.0;
 				targetRef.current = 1.0;
+
+				// 瞬時着地のときだけ追従させる。smooth はブラウザ側のスクロール
+				// アニメーションと競合するため行わない
+				if (behavior === "auto") {
+					holdProgressUntilRef.current =
+						performance.now() + REANCHOR_DURATION_MS;
+					keepAnchored(measureTop);
+				}
 
 				// しばらくしたらフラグを戻す
 				setTimeout(() => {
@@ -622,13 +714,12 @@ function MissionSection(
 		const container = containerRef.current;
 		if (!container) return;
 
-		if (isCircleFullyExpanded && scrollPositionRef.current > 0) {
-			container.scrollTop = scrollPositionRef.current;
-		}
-
 		if (!isCircleFullyExpanded) {
+			// 進行中の再アンカーを止めてから畳む（止めないとリセット直後に貼り直される）
+			reanchorCleanupRef.current?.();
+			holdProgressUntilRef.current = 0;
+
 			container.scrollTop = 0;
-			scrollPositionRef.current = 0;
 
 			currentRef.current = 0;
 			targetRef.current = 0;

--- a/src/app/service/components/example-list-accordion.tsx
+++ b/src/app/service/components/example-list-accordion.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { ChevronDown } from "lucide-react";
-import Link from "next/link";
 import { useState } from "react";
+import { HashJumpLink } from "@/components/lp/hash-jump-link";
 
 interface ExampleListAccordionProps {
 	items: string[];
@@ -52,12 +52,12 @@ export function ExampleListAccordion({ items }: ExampleListAccordionProps) {
 				<p className="mt-4 text-xs leading-relaxed text-muted-foreground">
 					その他、課題に感じていることがありましたら、
 					<br />
-					<Link
+					<HashJumpLink
 						href="/#contact"
 						className="font-bold text-foreground underline underline-offset-4 hover:text-[#e8590c] transition-colors"
 					>
 						お気軽にご相談ください
-					</Link>
+					</HashJumpLink>
 					。
 				</p>
 			</div>

--- a/src/components/lp/CtaBlock.tsx
+++ b/src/components/lp/CtaBlock.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { anton } from "./fonts";
+import { HashJumpLink } from "./hash-jump-link";
 
 export function CtaBlock() {
 	return (
@@ -17,7 +17,7 @@ export function CtaBlock() {
 				<br className="hidden lg:inline" />
 				初回の相談は無料です。
 			</p>
-			<Link
+			<HashJumpLink
 				href="/#contact"
 				className="group inline-flex items-center gap-3 rounded-full bg-white px-10 py-5 text-base font-bold text-[#1c50a1] transition-transform hover:scale-[1.03] active:scale-95"
 			>
@@ -28,7 +28,7 @@ export function CtaBlock() {
 				>
 					→
 				</span>
-			</Link>
+			</HashJumpLink>
 		</section>
 	);
 }

--- a/src/components/lp/hash-jump-link.tsx
+++ b/src/components/lp/hash-jump-link.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps } from "react";
+import { markHashJump } from "@/lib/hash-jump";
+
+type HashJumpLinkProps = ComponentProps<typeof Link>;
+
+/**
+ * `/#contact` のようにトップページのセクションへ飛ぶリンク。
+ *
+ * クリック時に markHashJump() を呼び、遷移先の HomeClient がスナップ完了まで
+ * 黒カバーを出せるようにする。見た目・挙動は next/link と同じ。
+ */
+export function HashJumpLink({ onClick, href, ...props }: HashJumpLinkProps) {
+	return (
+		<Link
+			href={href}
+			onClick={(event) => {
+				markHashJump();
+				onClick?.(event);
+			}}
+			{...props}
+		/>
+	);
+}

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -14,6 +14,7 @@ import {
 	Lightbulb,
 } from "lucide-react";
 import gsap from "gsap";
+import { markHashJump } from "@/lib/hash-jump";
 
 interface SidebarMenuProps {
 	onNavigate?: (path: string) => void;
@@ -303,9 +304,8 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 												} else if (item.href.startsWith("/#")) {
 													// LP等の別ページからハッシュ付きでトップへ遷移するとき、
 													// HomeClient が初回レンダリングから黒カバーを出せるように
-													// フラグを立てる（スナップ完了までの中間状態を見せないため）。
-													// キーはHomeClient.tsxのHASH_JUMP_FLAGと一致させること
-													sessionStorage.setItem("tanebi:hash-jump", "1");
+													// フラグを立てる（スナップ完了までの中間状態を見せないため）
+													markHashJump();
 												}
 												setIsOpen(false);
 											}}

--- a/src/lib/hash-jump.ts
+++ b/src/lib/hash-jump.ts
@@ -1,0 +1,21 @@
+/**
+ * ハッシュ付きでトップページへ遷移するときに立てるフラグ。
+ *
+ * トップは1000vhのスクロール演出ページで、セクションの表示はスクロール量に紐づく。
+ * 他ページから `/#contact` 等で来た場合は到達までにスナップ処理が入るため、
+ * その中間状態を黒カバーで隠す必要がある。HomeClient が初回レンダリングの時点で
+ * カバーを出せるよう、遷移元のクリック時に sessionStorage へ立てておく。
+ *
+ * sessionStorage を経由するのは SSR/直接アクセス時の hydration とずらすため。
+ * 直接アクセスはクリックを経ないのでフラグが無く、LoadingScreen が代わりに覆う。
+ *
+ * リンクを増やすときは HashJumpLink を使うこと。生の next/link で `/#...` を張ると
+ * カバーが出ず、スナップの中間状態がそのまま見えてしまう。
+ */
+export const HASH_JUMP_FLAG = "tanebi:hash-jump";
+
+/** ハッシュ付きトップ遷移の直前に呼ぶ。フラグは HomeClient 側で1回使い切る */
+export function markHashJump() {
+	if (typeof window === "undefined") return;
+	sessionStorage.setItem(HASH_JUMP_FLAG, "1");
+}


### PR DESCRIPTION
## 概要

`/service` の CTA などから `/#contact` へ遷移すると、CONTACT ではなく MISSION の演出が頭から再生される状態で止まることがありました。競合状態が原因で、クライアント遷移では構造的に毎回発生します。

## 原因

`isCircleFullyExpanded` が2箇所から書かれていました。

- `navigateToHash` が `true` を強制する（`HomeClient.tsx`）
- RAF ループが**平滑化済みスクロール値から再計算して `false` に戻す**（1フレームあたり差分の8%で追従）

`window.scrollTo` は一瞬で最下部へ飛びますが、補間が追いつくには約43フレーム（60fpsで約717ms）かかります。一方 `scrollToContact` が呼ばれるのは `150ms + 300ms = 450ms` 後で、この時点の補間値は **0.777**。つまり `isCircleFullyExpanded` は必ず `false` です。

`false` の間は `rawTarget = 0` となって MissionSection の進行度が 1.0 から引き戻され、約75ms で `overflow-hidden` が復帰し、進行中のコンテナ内スクロールが失われます。その後 `PROGRESS_SPEED_FORWARD = 0.25`（デスクトップ）で MISSION の演出が3.3秒かけて再生されるため、添付の症状になります。

URL直打ちでは `LoadingScreen` が約700ms 覆って補間が追いつく窓と重なるため、`<Link>` によるクライアント遷移でのみ壊れていました。

## 変更内容

- **`syncScrollLerp` を追加**。`window.scrollTo({ behavior: "auto" })` の直後に補間値を実位置へ同期し、`isCircleFullyExpanded` の巻き戻しを断つ
- 根拠のない固定300msの待ちを二重 `requestAnimationFrame` に置き換え
- 動的インポート（`MissionContent` 等）の解決でコンテンツが伸びても着地点がずれないよう、着地後600msのあいだ位置を測り直して貼り直す。ホイール・タッチ・キー操作を検知したら即座に中断する
- ハッシュ遷移時の内部スクロールを `smooth` → `auto` に変更。黒カバーの下で位置を決めるため、スムーズスクロールの完了待ちという不確定要素が不要になる。トップページ上のメニュー操作は `smooth` のまま（引数で切り替え）
- トップページ上のナビクリックが持っていた別実装（約70行）を削除し `navigateToHash` に統合
- `src/lib/hash-jump.ts` と `HashJumpLink` を新設し、`CtaBlock` と例示リストのリンクを差し替え。これまで黒カバーのフラグを立てていたのはグローバルメニューだけで、CTA 経由では中間状態が丸見えだった
- 書き込み箇所が存在せず常に0だった `scrollPositionRef` を削除
- 親プロップの伝搬が1〜2フレーム遅れた場合に備え、着地直後は進行度の算出を継続する `holdProgressUntilRef` を追加

## 挙動が変わる点

トップページ上でのメニュークリックが、これまでの「1000vh をスムーズスクロール」から瞬時のスナップになります。壊れていた側の実装を消した結果で、意図的な変更です。

## 動作確認

`pnpm lint` エラー0件、`pnpm build` 成功。以下は実機での確認が必要です。

- `/service#web` / `/service/issues` の CTA → CONTACT フォームに着地
- 例示リスト内の「お気軽にご相談ください」→ 同上
- グローバルメニュー（LP上から）→ CONTACT / MISSION / ABOUT
- トップページ上でメニュー → 各セクション
- 着地後にブラウザの戻る

## 関連

- 該当の実装が入った PR: #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n