### PR TITLE
perf(top): トップページの描画負荷を下げレイアウトシフトを解消

### DIFF
--- a/src/components/three/HtmlHoverPointer.tsx
+++ b/src/components/three/HtmlHoverPointer.tsx
@@ -1,62 +1,135 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 interface HtmlHoverPointerProps {
 	isHovering: boolean;
 }
 
+/** 円の直径。translate(-50%, -50%) で中心をマウス位置に合わせている */
+const SIZE_PX = 160;
+/** 1フレームあたり目標値に近づく割合 */
+const LERP = 0.15;
+/** これ以下の差は収束とみなして目標値に吸着させる */
+const EPSILON = 0.001;
+
 /**
- * HTMLレイヤーで表示するhoverポインタ
- * 流体エフェクトの影響を受けない
+ * 3Dカードにホバーしたときにマウス位置へ出る「CLICK」の円。
+ * 流体エフェクトの影響を受けないよう、Canvas ではなく HTML レイヤーで描く。
+ *
+ * 実装上の要点が3つある。
+ *
+ * 1. 位置は left/top ではなく transform で動かす。
+ *    left/top はレイアウト計算を伴うため、マウス移動のたびにレイアウトシフトとして
+ *    計上されていた（DevTools の CLS で、カードにホバーしている間だけ shifts が
+ *    増え続け、カード外に出ると止まる挙動として実測できた）。
+ *    transform での移動はレイアウトを起こさないので、この計上自体が無くなる。
+ *
+ * 2. React の state を持たない。
+ *    以前は mousemove のたびに setState していたため、マウスを動かす限り
+ *    再レンダリングが発生していた。座標もスケールも ref に持ち、DOM を直接書く。
+ *
+ * 3. rAF は1本だけ、しかも仕事が無くなったら止める。
+ *    以前はスケール用の rAF が、目標値に到達したあとも毎フレーム自分を予約し続けて
+ *    いた。ホバーしていない間も回りっぱなしになる明確な不具合だった。
  */
 export function HtmlHoverPointer({ isHovering }: HtmlHoverPointerProps) {
-	const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
-	const [scale, setScale] = useState(0);
-	const rafRef = useRef<number | undefined>(undefined);
+	const elementRef = useRef<HTMLDivElement>(null);
+	const pointerRef = useRef({ x: 0, y: 0 });
+	const scaleRef = useRef(0);
+	const targetScaleRef = useRef(0);
+	const rafRef = useRef<number | null>(null);
+	// isHovering 側の effect から呼ぶため、スケジューラを ref 経由で公開する
+	const scheduleRef = useRef<() => void>(() => {});
 
 	useEffect(() => {
-		const handleMouseMove = (e: MouseEvent) => {
-			setMousePos({ x: e.clientX, y: e.clientY });
+		const element = elementRef.current;
+		if (!element) return;
+
+		const render = () => {
+			// scale → translate(-50%, -50%) → translate3d の順に効くため、
+			// 拡大率にかかわらず円の中心がマウス位置に一致する
+			element.style.transform = `translate3d(${pointerRef.current.x}px, ${pointerRef.current.y}px, 0) translate(-50%, -50%) scale(${scaleRef.current})`;
 		};
 
-		window.addEventListener("mousemove", handleMouseMove);
-		return () => window.removeEventListener("mousemove", handleMouseMove);
+		// tick と schedule は相互に呼び合う。schedule は tick より後に定義されるが、
+		// 実際に呼ばれるのは初期化後なので問題ない
+		const tick = () => {
+			rafRef.current = null;
+
+			const diff = targetScaleRef.current - scaleRef.current;
+			if (Math.abs(diff) < EPSILON) {
+				scaleRef.current = targetScaleRef.current;
+			} else {
+				scaleRef.current += diff * LERP;
+			}
+
+			render();
+
+			if (scaleRef.current !== targetScaleRef.current) {
+				schedule();
+			} else if (scaleRef.current === 0) {
+				// 完全に消えたので合成レイヤーを手放す。常時 will-change を付けたままにすると
+				// レイヤー用のメモリを確保し続けてしまう
+				element.style.willChange = "auto";
+			}
+		};
+
+		const schedule = () => {
+			if (rafRef.current !== null) return;
+			element.style.willChange = "transform";
+			rafRef.current = requestAnimationFrame(tick);
+		};
+
+		scheduleRef.current = schedule;
+
+		const handlePointerMove = (event: PointerEvent) => {
+			pointerRef.current.x = event.clientX;
+			pointerRef.current.y = event.clientY;
+			// 見えていない間は DOM を触る必要がない。座標だけ覚えておき、
+			// ホバーが始まったときにまとめて反映する
+			if (targetScaleRef.current > 0 || scaleRef.current > 0) {
+				schedule();
+			}
+		};
+
+		render();
+		window.addEventListener("pointermove", handlePointerMove, {
+			passive: true,
+		});
+
+		return () => {
+			window.removeEventListener("pointermove", handlePointerMove);
+			if (rafRef.current !== null) {
+				cancelAnimationFrame(rafRef.current);
+				rafRef.current = null;
+			}
+		};
 	}, []);
 
 	useEffect(() => {
-		const targetScale = isHovering ? 1 : 0;
-
-		const animate = () => {
-			setScale((prev) => {
-				const diff = targetScale - prev;
-				if (Math.abs(diff) < 0.01) return targetScale;
-				return prev + diff * 0.15;
-			});
-			rafRef.current = requestAnimationFrame(animate);
-		};
-
-		rafRef.current = requestAnimationFrame(animate);
-
-		return () => {
-			if (rafRef.current) cancelAnimationFrame(rafRef.current);
-		};
+		targetScaleRef.current = isHovering ? 1 : 0;
+		scheduleRef.current();
 	}, [isHovering]);
 
 	return (
 		<div
+			ref={elementRef}
 			style={{
 				position: "fixed",
-				left: mousePos.x,
-				top: mousePos.y,
-				width: "160px",
-				height: "160px",
+				// 位置は transform で与えるため、基準は常にビューポート左上に固定する
+				left: 0,
+				top: 0,
+				width: `${SIZE_PX}px`,
+				height: `${SIZE_PX}px`,
 				borderRadius: "50%",
 				backgroundColor: "white",
-				transform: `translate(-50%, -50%) scale(${scale})`,
+				// この文字列は毎レンダリング同じ値でなければならない。
+				// 値が変わると React が DOM に書き戻し、上の effect が直接書いた
+				// transform を打ち消してしまう（同じ値なら React は DOM を触らない）
+				transform: "translate3d(0px, 0px, 0) translate(-50%, -50%) scale(0)",
 				pointerEvents: "none",
 				zIndex: 9999,
-				transition: "transform 0.1s ease-out",
 				display: "flex",
 				alignItems: "center",
 				justifyContent: "center",

--- a/src/components/three/hero-canvas.tsx
+++ b/src/components/three/hero-canvas.tsx
@@ -363,10 +363,21 @@ function HeroScene({
 		const isMobileFrame = state.size.width < 768;
 
 		// ★パフォーマンス最適化: 条件付きFBO更新
-		// - ホバー中（hoverStrength > 0.1）: 毎フレーム更新
-		// - アイドル時: 3フレームに1回更新（約66%のGPU負荷削減）
+		// - カードに実際にホバー中: 毎フレーム更新
+		// - それ以外（アイドル時・液体演出の揺れがscroll<0.97のほぼ全域で反応中でも）: 3フレームに1回更新
+		//
+		// 以前は hoverStrength > 0.1 を条件にしていたが、hoverStrength は液体演出の
+		// 「揺れ」の強さで、isTop（scroll < 0.97、1000vhのほぼ全区間）や isSpace が
+		// 真になるだけで1になる。つまりトップページ上でマウスを動かすだけで
+		// ほぼ常時「毎フレームFBO更新」になり、画面全体を毎フレーム2回描画していた。
+		//
+		// 液体演出の揺れそのもの（uIntensity、見た目）はこれまでどおり広い範囲で
+		// 反応させたいという経緯があるため hoverStrength は変更せず、
+		// 一番コストの高い「FBOを毎フレーム更新するか」の判定だけをカードへの
+		// 実際のホバーに絞る。カードから離れた場所での揺れは、3フレームに1回の
+		// 更新でも見た目の破綻はほぼ無い（背景の星・星雲はゆっくりとしか動かないため）。
 		frameCountRef.current++;
-		const isHoverActive = hoverStrength.current > 0.1;
+		const isHoverActive = isCardHoveringRef.current;
 		const shouldUpdateFbo =
 			isHoverActive || frameCountRef.current - lastFboUpdateRef.current >= 3;
 


### PR DESCRIPTION
## 概要

トップページの体感カクつきの調査から、2つの負荷源を見つけて修正しました。片方は実測で効果を確認できています。

## 1. ホバー円のレイアウトシフト（実測で確認済み）

### 症状

DevTools の Live metrics で、CLS の shifts が異常に多く積み上がっていました（Worst cluster **176 shifts**）。オーナーの観察により、**3Dカードにホバーしている間だけ増え続け、カード外に出ると止まる**ことが判明しました。

### 原因

`HtmlHoverPointer` が位置を `left` / `top` で更新していました。これらはレイアウト計算を伴うプロパティのため、マウス移動のたびにレイアウトシフトとして計上されます。`scale(0)` の間は視覚的な面積がゼロでスコアが0になるため、カード外では止まって見えていました。

`position: fixed` だから安全、という理解は誤りです。fixed で CLS から除外されるのはスクロールに伴う見かけ上の移動であって、`left` / `top` の変更ではありません。また `mousemove` は `hadRecentInput` の除外対象（クリック・タップ・キー入力などの離散的な入力）に当たらないため、除外されずに全て計上されます。

### 修正

- 位置とスケールを `transform: translate3d() + scale()` に一本化。transform による移動はレイアウトを起こさないため、計上自体が無くなる
- React の state を廃止し ref + 直接DOM操作に変更。`mousemove` のたびに再レンダリングが走る状態を解消
- **rAF を1本にまとめ、収束したら停止するようにした**。以前は目標値に到達したあとも毎フレーム自分を予約し続けており、ホバーしていない間も回りっぱなしになる明確な不具合だった
- 見えていない間は DOM を触らない（座標は ref に記録し、ホバー開始時に反映）
- `will-change` は表示中のみ付与し、消えたら手放す
- CSS の `transition: transform` を削除（JS側の補間と二重になっていた）

### 検証結果

修正後、同じ操作をしても **shifts が増えなくなりました**。`PerformanceObserver` で `layout-shift` を監視しても、ホバー中にエントリが1件も発生しません。

```js
new PerformanceObserver((list) => {
  for (const e of list.getEntries()) {
    if (!e.hadRecentInput) console.log(e.value, e.sources);
  }
}).observe({ type: "layout-shift", buffered: true });
```

## 2. FBO の毎フレーム更新（見た目の確認のみ）

液体演出用に画面全体をもう一度描画してキャプチャする処理（FBO更新）を毎フレーム行うかどうかの判定が `hoverStrength > 0.1` になっていました。`hoverStrength` は演出の揺れの強さを表す値で、`isTop`（`scroll < 0.97`、1000vhのほぼ全区間）が真になるだけで1になります。つまり**トップページ上でマウスを動かすだけでほぼ常時「毎フレーム画面全体を2回描画」**していました。

演出の揺れそのもの（見た目の反応範囲）は経緯があって広く取っているため `hoverStrength` は変更せず、コストの高い「FBOを毎フレーム更新するか」の判定だけを、カードへの実際のホバー（`isCardHoveringRef`）に絞りました。

カードから離れた場所での揺れはアイドル時と同じ3フレームに1回の更新になりますが、背景の星・星雲はゆっくりとしか動かないため見た目の破綻はありません（目視確認済み）。

## レビュー

codex にレビューさせ、因果関係・深刻度・修正方針の妥当性を確認しています。判定は「仮説は妥当」で、優先順位は「最優先で即修正すべき」に格上げされました。

## 補足

blog のカーソル追従は WebGL のメッシュを動かしており `left/top` は使っていないため、CLS への影響はありません。`useFrame` 内で毎フレーム `setState` している別の問題は、既知の未着手項目として残ります。

## 動作確認

`pnpm lint` エラー0件、`pnpm build` 成功。ローカルで shifts が増えないこと、円の追従・拡大縮小の見た目、液体演出の見た目を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n