### PR TITLE
docs: READMEを現状に合わせて更新し残作業ロードマップを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,3 +348,7 @@ vertex/fragment ペア8組のシェーダーを `public/shaders/` に配置し�
 
 PR 作成時に GitHub Actions で Biome lint + Next.js build チェックを自動実行します。main ブランチへのマージで Vercel に自動デプロイされます。
 
+## 今後の予定
+
+着手待ちの課題と、実装時に守るべき事項（過去に踏んだ落とし穴）は [`docs/roadmap.md`](docs/roadmap.md) にまとめています。
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ https://github.com/user-attachments/assets/9b5a6d05-6d35-423d-b108-a62fcf70b035
 |---|---|
 | 技術力や事業内容を伝える場所がなく、クライアントへの窓口もありませんでした | インタラクティブな 3D サイトで技術力を体験として伝え、実際にお問い合わせ獲得にもつながりました |
 | 知見の発信・SEO による継続的な集客ができていませんでした | ブログ機能を実装し、記事ベースの発信・検索流入の基盤を構築しました |
+| 「何を頼めるのか」が伝わらず、相談前に離脱されていました | サービス紹介ページを追加し、困りごとから相談メニューへ辿れる導線を用意しました |
+| 演出が重く、一般的な回線・端末では表示に 20 秒かかっていました | 実測にもとづく最適化で LCP 20.2 秒 → 4.5 秒、総転送量 3.99MB → 1.79MB に改善しました |
 
 ---
 
@@ -49,7 +51,9 @@ TANEBI（種火）という社名には、暗闇の中にある小さな火—�
 
 ### フォント
 
-システムフォント（Arial / sans-serif）を基本とし、Web フォントの読み込みを排除することでファーストビューの表示速度を優先しています。3D シーンの初期ロードが重いサイト特性を踏まえ、フォント起因のレンダリングブロックをゼロにする設計としました。
+トップページはシステムフォント（Arial / sans-serif）を基本とし、Web フォントの読み込みを排除することでファーストビューの表示速度を優先しています。3D シーンの初期ロードが重いサイト特性を踏まえ、フォント起因のレンダリングブロックをゼロにする設計としました。
+
+下層のサービス紹介ページ（`/service`, `/service/issues`）は 3D シーンを持たず、読み物としての可読性を優先するため、`next/font/google` で Anton（英字ディスプレイ）と Noto Sans JP（本文・和文見出し）を読み込んでいます。適用範囲は LP のコンテナに限定し、トップページには影響させていません。
 
 </details>
 
@@ -185,6 +189,8 @@ graph LR
 graph TB
     subgraph Server["Server Components (RSC)"]
         TopPage["トップページ<br/>page.tsx"]
+        ServiceMenu["ご相談メニュー<br/>service/page.tsx"]
+        ServiceIssues["課題から探す<br/>service/issues/page.tsx"]
         BlogList["ブログ一覧<br/>blog/page.tsx"]
         BlogPost["ブログ記事<br/>blog/[slug]/page.tsx"]
     end
@@ -201,7 +207,11 @@ graph TB
 
     TopPage -->|"dynamic import<br/>ssr: false"| ThreeJS
     TopPage --> Animations
-    TopPage --> Form
+    TopPage -->|"dynamic import"| Form
+    ThreeJS -->|"3Dカードから遷移"| ServiceMenu
+    ThreeJS -->|"3Dカードから遷移"| ServiceIssues
+    ServiceMenu -->|"CTA → /#contact"| TopPage
+    ServiceIssues -->|"CTA → /#contact"| TopPage
     Form -->|"action"| Contact
     BlogList -->|"await fetch"| CMS["microCMS"]
     BlogPost -->|"await fetch"| CMS
@@ -223,10 +233,27 @@ Three.js コンポーネントは `dynamic(() => import("./hero-canvas"), { ssr:
 
 - **3D 初期化の遅延**: `requestIdleCallback` で Canvas マウントと GLB プリロードをブラウザのアイドル時まで遅延させ、初期ロードのメインスレッドブロックを回避
 - **Canvas 描画の動的制御**: Mission セクション表示中は `frameloop="never"` で GPU レンダリングを完全停止し、バッテリー消費とモバイル発熱を抑制
-- **GLB モデルの最適化**: gltf-transform によるメッシュ簡略化・テクスチャリサイズ・Draco 再圧縮で 6.8MB → 3.6MB に削減
+- **GLB モデルの最適化**: Blender のヘッドレス decimate（`scripts/decimate-glb.py`）でメッシュを簡略化し、3.58MB → 0.83MB（-77%）、GPU 展開後メモリ 18.5MB → 2.03MB（-89%）に削減。重さの実体はテクスチャではなくメッシュ密度（141,346 三角形）だった
 - **webpack splitChunks**: Three.js（three / @react-three / three-stdlib）と Framer Motion を独立チャンクに分離し、初期バンドルサイズを削減
 - **SSR 空白の解消**: Providers の `isMounted` パターンを除去し、初期 HTML を出力することで Lighthouse の FCP/LCP 計測を可能に
-- **LoadingScreen の CSS 化**: ローディング画面から Three.js Canvas を除去し、CSS アニメーションのみで実装。WebGL コンテキストの初期化を 2 回 → 1 回に削減
+- **LoadingScreen の見直し**: Three.js Canvas を除去して CSS アニメーションのみで実装。演出時間を 2.5 秒 → 0.7 秒に短縮し、`overflow: hidden` によるスクロール封鎖も撤去。実ロードと無関係な演出のために回線速度によらず本文到達を遅らせていた
+- **可変フォントの `@font-face` 重複解消**: Noto Sans JP に `weight` を列挙していたため、同一の `.woff2` を指す定義が 4 倍に複製されていた（実測 497 個 / 参照先は 124 個）。`weight` を省略して可変定義にすることで、全ウェイトを維持したままレンダーブロッキング CSS を 368KB → 92KB（gzip 122KB → 30KB）に削減
+- **重いライブラリの遅延読み込み**: 3D 背景・お問い合わせフォーム（zod / react-hook-form / Radix / sonner）を `next/dynamic` に切り出し、トップの初期バンドルから除外。TBT 1,130ms → 80ms、メインスレッド処理 13.3 秒 → 2.2 秒
+- **空の middleware を削除**: `NextResponse.next()` を返すだけの実装が全リクエストに乗っていた
+- **レイアウトシフトの解消**: マウス追従の円を `left` / `top` から `transform` に変更。`left` / `top` はレイアウト計算を伴うため、マウス移動のたびにレイアウトシフトとして計上されていた（DevTools で実測し、修正後は発生しないことを確認）
+- **FBO 更新条件の適正化**: 液体エフェクト用に画面全体を再描画する処理が、スクロール量 97% 未満というほぼ全区間で毎フレーム走っていたため、3D カードへの実際のホバー時に限定
+
+本番実測（Lighthouse モバイル）: スコア 46 → 74、LCP 20.2 秒 → 4.5 秒、TBT 1,710ms → 130ms、総転送量 3.99MB → 1.79MB。
+
+### ページ構成と、1000vh ページ特有のハッシュ遷移
+
+トップページはスクロール量に演出が紐づく 1000vh の 1 枚ページで、Mission / About / Contact は**実 URL を持たないセクション**です。そのためブラウザ標準のアンカージャンプでは演出の状態が追いつかず到達できません。
+
+到達処理は `navigateToHash()` の 1 箇所に集約し、「他ページからの初回ロード」「戻る/進む（popstate）」「同一ページ内のハッシュ変更（hashchange）」「ページ内のナビクリック」の全経路がここを通る設計にしています。スナップ完了までの中間状態は黒いカバーで隠します。
+
+この構造で一度踏んだ落とし穴として、**スクロール量を平滑化して追従する RAF ループが、瞬間移動したスクロール位置に追いつくまで約 717ms かかり、その間セクションの表示状態を巻き戻してしまう**というものがありました。`window.scrollTo({ behavior: "auto" })` の直後に補間値を実位置へ同期させることで解消しています。
+
+トップの 3D 回転カードは、配下ページへの導線として固定 3 枚を定義しています（`showcase-cards.ts`）。以前は microCMS のブログ記事から生成していましたが、記事を書くたびにファーストビューが変わってしまうため、記事一覧は `/blog` に任せる構成に変更しました。
 
 ### 三層アニメーション設計
 
@@ -234,7 +261,11 @@ Three.js コンポーネントは `dynamic(() => import("./hero-canvas"), { ssr:
 
 ### SEO（AIO/LLMO）対応
 
-JSON-LD 構造化データ（Organization, WebSite, Service）をトップページに埋め込み、ブログ記事には動的メタデータを生成しています。`llms.txt` を配置して LLM クローラー向けの情報を提供し、`robots.txt` で GPTBot・Claude-Web・PerplexityBot 等の AI クローラーを許可しています。
+JSON-LD 構造化データ（Organization, WebSite, Service）をトップページに埋め込み、ブログ記事には動的メタデータを生成しています。`llms.txt` にサイト概要と主要ページの一覧を記載し、`robots.txt` で AI クローラーを明示的に許可しています。
+
+クローラー名は各社が変更するため、公式ドキュメントで確認したうえで、**学習用・検索用・ユーザー起点アクセスの3種類をそれぞれ指定**しています（OpenAI: `GPTBot` / `OAI-SearchBot` / `ChatGPT-User`、Anthropic: `ClaudeBot` / `Claude-SearchBot` / `Claude-User`、ほか PerplexityBot・Google-Extended・Applebot-Extended・CCBot・bingbot）。かつて指定していた `Claude-Web` と `anthropic-ai` は既に廃止されており、検索用の `Claude-SearchBot` が許可されていない状態になっていました。
+
+**AI クローラーは基本的に JavaScript を実行しません。** そのため事業説明のような中核コンテンツは、クライアント側でしか描画されない構造にしないことが前提になります。実際にこのサイトでも Mission セクションが `ssr: false` で初期 HTML に一切出力されておらず、AI 検索から見て存在しないのと同じ状態になっていたため、SSR に戻して解消しました。
 
 ## ディレクトリ構成
 
@@ -244,21 +275,31 @@ src/
 │   ├── actions/          # Server Actions (お問い合わせ)
 │   ├── api/              # API ルート (microCMS Webhook)
 │   ├── blog/             # ブログ機能 (microCMS連携, SSG)
+│   ├── service/          # サービス紹介ページ
+│   │   ├── page.tsx      #   できること ─ ご相談メニュー
+│   │   ├── issues/       #   その課題、ここから伸ばせます
+│   │   └── components/   #   ページ固有UI (アコーディオン, 上に戻るボタン)
+│   ├── works/            # 実績ページ (再設計中・noindex)
 │   ├── components/       # ページ固有コンポーネント (Colocation)
 │   ├── page.tsx          # トップページ (RSC, JSON-LD)
 │   └── sitemap.ts        # 動的サイトマップ生成
 ├── components/
 │   ├── three/            # Three.js 3Dシーン (16 GLSLシェーダー)
+│   ├── lp/               # サービス紹介ページ用の共通パーツ・フォント定義
 │   ├── blog/             # ブログUI
 │   ├── contact/          # お問い合わせフォーム
 │   └── ui/               # 共通UIコンポーネント (shadcn/ui)
-├── lib/                  # ユーティリティ (microCMS, SEO, sanitize)
+├── lib/                  # ユーティリティ (microCMS, SEO, sanitize, hash-jump)
 ├── contexts/             # React Context
 └── types/                # 型定義
 public/
 ├── shaders/              # GLSLシェーダーファイル (16本)
+├── models/               # GLBモデル (Draco圧縮)
 ├── llms.txt              # LLMクローラー向け情報
 └── robots.txt            # クローラー制御
+scripts/
+├── decimate-glb.py       # Blenderヘッドレスによるメッシュ簡略化
+└── measure-page-weight.mjs  # ビルド後HTMLから実際に読まれるJS/CSSを実測
 ```
 
 ## 実装ハイライト

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,80 @@
+# 残作業ロードマップ
+
+このサイトで着手待ちになっている技術的な課題の一覧。
+最終更新: 2026-08-17（PR #189 で本番リリース済みの状態）
+
+> 実測値・判断の経緯・コピー方針などの詳細は、リポジトリ管理外の `doc/progress.md` にある。
+> このファイルは「何が残っているか」と「なぜ必要か」を公開できる範囲で記録するもの。
+
+---
+
+## 着手待ちの項目
+
+### 1. TANEBI CREATIVE 詳細ページの作成
+
+トップページの 3D カード 1 枚目のリンク先が、詳細ページ未作成のため暫定で `/#about`（トップ内の ABOUT セクション）を指している。ページを作成したら `src/components/three/showcase-cards.ts` の `liveUrl` を差し替えるだけでよい。
+
+### 2. `/blog` 一覧ページを sitemap に戻す
+
+記事が 0 件だった時期に `src/app/sitemap.ts` から除外したまま戻していない。個別記事（`/blog/:id`）は動的に生成されるが、一覧ページ自体が載っていない。本番には実記事があるため、戻す判断ができる状態。
+
+### 3. `/blog` のカーソル追従を DOM 実装に置き換える
+
+`src/app/blog/layout.tsx` がマウス追従の円 1 個のために `MousePointer` を静的インポートしており、three-vendor（gzip 196KB）と react-reconciler（gzip 33KB）の計 **229KB** がブログ全ページに載っている。CSS の `transform` で代替できる。
+
+同ファイルは `useFrame` 内で `setState` しており、毎秒 60 回の再レンダリングが走る問題も抱えている。トップページの `HtmlHoverPointer` で採用した「ref + 単一 rAF + `transform`」の実装に揃えるのが自然。
+
+### 4. GLB のモバイル条件ロード
+
+`Astronaut.tsx` の `useGLTF("/models/artro_draco.glb")` は 0.83MB（Blender の decimate で 3.58MB から削減済み）。モバイルでも無条件で読み込んでおり、位置と縮尺が変わるだけになっている。回線と GPU メモリの負担を考えると、モバイルでは静止画へのフォールバックや読み込み自体の見送りを検討する余地がある。
+
+### 5. Next.js 16 移行（15.5.16 → 16.x）
+
+**唯一の実質的なブロッカーは `next.config.ts` の `webpack()`。** Next 16 は `next build` が Turbopack 既定になり、webpack 設定があるとビルドが失敗する。
+
+- `.glsl` の raw-loader → `turbopack.rules` へ移行可能
+- `splitChunks.cacheGroups`（three / framer-motion の分離）→ Turbopack に同等機能がないため、自動分割に任せて `scripts/measure-page-weight.mjs` で実測して判断する
+- 逃げ道として `next build --webpack` がある
+
+影響がないことを確認済みの項目: async params / cookies / headers / draftMode（すべて `await` 済み）、並列ルート、AMP、`next lint`（Biome を使用）、`runtimeConfig`、`unstable_*`、`scroll-behavior: smooth`、`quality` prop。キャッシュ API の破壊的変更も、`unstable_cache` / `revalidateTag` / `export const revalidate` の使用が 0 件のため影響しない。
+
+あわせて `packageManager` を pnpm 10.26 以降に固定し、`pnpm-workspace.yaml` に `minimumReleaseAge` 等のサプライチェーン対策を入れるのが自然なタイミング。
+
+### 6. `/works` の再設計
+
+現在 noindex で据え置き。sitemap からも除外している。
+
+### 7. コピーの見直し
+
+サービス紹介ページとトップページの文言を、事業ポジショニングに合わせて刷新する。方針と承認済みの案は `doc/progress.md` にある。
+
+---
+
+## 実装時に守ること
+
+過去に踏んだ落とし穴。同種の実装を追加するときは必ず確認する。
+
+### `window.scrollTo({ behavior: "auto" })` の直後は `syncScrollLerp()` を呼ぶ
+
+トップページはスクロール量を平滑化して追従する RAF ループを持つ（1 フレームあたり差分の 8%）。瞬間移動したスクロール位置に追いつくまで **約 717ms（60fps で 43 フレーム）** かかり、その間ループは「まだ画面上部にいる」と判断してセクションの表示状態を巻き戻す。補間値を実位置へ同期させることでこれを断つ。
+
+### `/#...` のリンクは `HashJumpLink` を使う
+
+生の `next/link` で `/#contact` などを張ると、スナップ完了までの中間状態を隠す黒カバーのフラグが立たず、遷移の途中経過がそのまま見えてしまう。`src/components/lp/hash-jump-link.tsx` を使う。
+
+### マウス追従 UI は `left` / `top` ではなく `transform` で動かす
+
+`left` / `top` はレイアウト計算を伴うため、マウス移動のたびにレイアウトシフトとして計上される。DevTools で実測したところ、ホバー中に 176 件のシフトが積み上がっていた。`position: fixed` でも除外されない（fixed が CLS から除外するのはスクロールに伴う見かけ上の移動であって、`left` / `top` の変更ではない）。また `mousemove` は `hadRecentInput` の除外対象（クリック・タップ・キー入力などの離散入力）に当たらない。
+
+### ローカルでのビルド検証コマンド
+
+```bash
+NEXT_DIST_DIR=.next-verify pnpm dotenvx run -f .env.local -- pnpm exec next build
+```
+
+- 素の `pnpm build` は dotenvx を通らないため、microCMS の URL が暗号化文字列のままになりビルドが落ちる
+- `NEXT_DIST_DIR` で出力先を分けないと、稼働中の開発サーバーの `.next` を壊す（過去に 2 回発生）
+
+### 3D カードの画像は 3:2 で用意する
+
+カードの板は `CARD_W = 3, CARD_H = 2`（`VideoCard3D.tsx`）。テクスチャは板全体に引き伸ばされるため、正方形の画像を渡すと横方向に 1.5 倍伸びる。また `VideoCard3D.tsx` のテクスチャ読み込み失敗ハンドラは空で、**失敗してもエラーが出ずカードが白くなるだけ**なので、差し替え後は必ず目視で確認する。


### PR DESCRIPTION
## 概要

README が実装と食い違っている箇所を修正し、下層ページ追加後の構成を反映しました。あわせて、残作業の記録がリポジトリから辿れない問題を解消するため `docs/roadmap.md` を追加しています。

## 1. README の事実誤りの修正

ポートフォリオとして公開しているリポジトリなので、記述と実装の食い違いはそのまま信頼性に響きます。5箇所を修正しました。

| 箇所 | 誤 | 正 |
|---|---|---|
| フォント | 「Webフォントの読み込みを排除」 | 下層ページは `next/font/google` で Anton + Noto Sans JP を使用。トップページは従来どおりシステムフォント |
| GLB | 「gltf-transform で 6.8MB → 3.6MB」 | Blender の decimate で 3.58MB → **0.83MB**、GPU展開後 18.5MB → 2.03MB |
| AIクローラ | 「GPTBot・**Claude-Web**・PerplexityBot 等」 | `Claude-Web` と `anthropic-ai` は廃止済み。学習用・検索用・ユーザー起点の3種を各社ぶん指定 |
| LoadingScreen | 「CSS 化」のみ | 2.5秒 → 0.7秒への短縮と、`overflow: hidden` によるスクロール封鎖の撤去を追記 |
| ディレクトリ構成 | `service/`・`components/lp/`・`models/`・`scripts/` が欠落 | 追加 |

## 2. README への追記

- **パフォーマンス最適化の一覧**に、フォントCSSの重複解消・遅延読み込み・middleware削除・レイアウトシフト解消・FBO条件の適正化を追加。本番実測値（LCP 20.2秒 → 4.5秒、TBT 1,710ms → 130ms、総転送量 3.99MB → 1.79MB）も記載
- **レンダリング構成図**に下層ページと、3Dカードからの導線を追加
- **1000vh ページ特有のハッシュ遷移の設計**を新設。到達処理を1箇所に集約している理由と、平滑化ループが約717ms 追いつかない落とし穴を記載
- **SEO 節**に「AIクローラーは JavaScript を実行しない」前提と、Mission が `ssr: false` で初期HTMLに出ていなかった実例を追記
- **課題と解決の表**に、相談導線の整備とパフォーマンス改善を追加

## 3. `docs/roadmap.md` の追加

残作業の記録が `.gitignore` 対象の `doc/progress.md` にしかなく、リポジトリからも他の環境からも辿れない状態でした。技術的な内容は公開して問題ないため切り出しています。

- 着手待ちの7項目（詳細ページ作成、`/blog` の sitemap 復帰、blogカーソルのDOM化、GLBのモバイル条件ロード、Next.js 16 移行、`/works` 再設計、コピー見直し）
- 実装時に守ること（スクロール補間の同期、`HashJumpLink` の使用、`transform` での追従、ローカルビルド手順、カード画像の比率）

コピーの具体案と事業ポジショニングの詳細は、競合や見込み客に読まれて損する情報のため `doc/progress.md` 側に残しています（CLAUDE.md 1.6 のドキュメント配置判定に従う）。

## 動作確認

`pnpm lint` エラー0件。ドキュメントのみの変更でコードには触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n