### PR TITLE
perf(top): 液体シェーダーの局所化と未使用の毎フレーム計算の撤去

### DIFF
--- a/public/shaders/hover-fluid-fragment.glsl
+++ b/public/shaders/hover-fluid-fragment.glsl
@@ -98,18 +98,32 @@ void main() {
   float tail = 1.0 - smoothstep(uRadius * 1.7, uRadius * 1.7 + uFalloff * 1.3, length(uv - tailC));
   float ghost = tail * smoothstep(0.28, 0.6, vlen) * 0.55;
 
-  // とろみノイズ
-  vec2 nUv = uv * vec2(6.0 * aspect, 6.0) + vec2(uTime * 0.55, -uTime * 0.48) + vel * 1.4;
-  float n1 = fbm(nUv);
-  float n2 = fbm(nUv + vec2(19.3, -11.7));
-  vec2 flow = (vec2(n1, n2) - 0.5) * 2.0;
+  // ★パフォーマンス最適化: ポインター由来の変位を局所化
+  //
+  // disp の各項は bulge（= mask を掛けた値）、mask、ghost のいずれかに掛かる。
+  // つまり mask も ghost も 0 の画素では disp は厳密に 0 になり、
+  // ここで計算する fbm 2回（= noise 6回 = hash 24回）は結果に一切寄与しない。
+  //
+  // ポインターの影響半径は uRadius(0.095) + uFalloff(0.165) 程度で画面の一部にすぎず、
+  // さらに mask には uIntensity が掛かるため、マウスが止まって uIntensity が減衰すると
+  // 全画面で 0 になる。したがって大半の画素・大半の時間でこの計算を丸ごと省ける。
+  //
+  // 出力は分岐前と完全に一致する（見た目は変わらない）。
+  vec2 disp = vec2(0.0);
+  if(mask > 0.0 || ghost > 0.0) {
+    // とろみノイズ
+    vec2 nUv = uv * vec2(6.0 * aspect, 6.0) + vec2(uTime * 0.55, -uTime * 0.48) + vel * 1.4;
+    float n1 = fbm(nUv);
+    float n2 = fbm(nUv + vec2(19.3, -11.7));
+    vec2 flow = (vec2(n1, n2) - 0.5) * 2.0;
 
-  vec2 ndir = normalize(rel + 1e-6);
-  vec2 tangent = vec2(-ndir.y, ndir.x);
-  vec2 disp = ndir * (0.70 * bulge) +
-    tangent * (0.38 * bulge) +
-    flow * (uNoiseAmp * mask) +
-    (-dir) * (0.30 * ghost);
+    vec2 ndir = normalize(rel + 1e-6);
+    vec2 tangent = vec2(-ndir.y, ndir.x);
+    disp = ndir * (0.70 * bulge) +
+      tangent * (0.38 * bulge) +
+      flow * (uNoiseAmp * mask) +
+      (-dir) * (0.30 * ghost);
+  }
 
   vec2 dispCombined = baseDisp * uBaseAmp + disp * uDispAmp;
 

--- a/src/components/three/hero-canvas.tsx
+++ b/src/components/three/hero-canvas.tsx
@@ -336,14 +336,6 @@ function HeroScene({
 	const smoothedTheta = useRef(0);
 	const circleTRef = useRef(0);
 
-	// ヒーロー領域算出ワーク
-	const box = useMemo(() => new THREE.Box3(), []);
-	const tmp = useMemo(() => new THREE.Vector3(), []);
-	const corners = useMemo(
-		() => Array.from({ length: 8 }, () => new THREE.Vector3()),
-		[],
-	);
-
 	// ===== 毎フレーム =====
 	useFrame((state, delta) => {
 		// ★パフォーマンス最適化: Missionセクション表示中（スクロール完了後）で、かつContactが表示されていない時は、
@@ -377,43 +369,19 @@ function HeroScene({
 		velSmoothed.current.lerp(velNow, kVel);
 		lastMouseFiltered.current.copy(mouseFiltered.current);
 
-		// HoverFluid のヒーロー領域更新
+		// HoverFluid の uniform 更新
+		//
+		// ★パフォーマンス最適化: ヒーロー領域（uHeroCenter / uHeroSize / uHeroRadius）の
+		// 毎フレーム計算を撤去した。
+		// これらは液体エフェクトを画面の一部に限定するためのものだったが、
+		// シェーダー側は `float heroMask = 1.0;` と直書きされていて
+		// roundRectMask() の呼び出しがコメントアウトされており、実際には使われていない。
+		// にもかかわらず毎フレーム、三角形グループとカードグループに対して
+		// Box3.expandByObject（サブツリー全体を走査してバウンディングボックスを再計算）を行い、
+		// 8頂点をカメラへ射影していた。結果を誰も読まない計算だった。
+		// 領域限定を復活させるときは、シェーダー側の heroMask を戻したうえでここも戻すこと。
 		const u = hoverMatRef.current?.uniforms;
 		if (u) {
-			let minX = 1,
-				minY = 1;
-			let maxX = -1,
-				maxY = -1;
-			box.makeEmpty();
-			if (triangleGroupRef.current)
-				box.expandByObject(triangleGroupRef.current);
-			if (videoCardsRef.current) box.expandByObject(videoCardsRef.current);
-
-			const bmin = box.min,
-				bmax = box.max;
-			const pts = corners;
-			pts[0].set(bmin.x, bmin.y, bmin.z);
-			pts[1].set(bmax.x, bmin.y, bmin.z);
-			pts[2].set(bmin.x, bmax.y, bmin.z);
-			pts[3].set(bmax.x, bmax.y, bmin.z);
-			pts[4].set(bmin.x, bmin.y, bmax.z);
-			pts[5].set(bmax.x, bmin.y, bmax.z);
-			pts[6].set(bmin.x, bmax.y, bmax.z);
-			pts[7].set(bmax.x, bmax.y, bmax.z);
-
-			for (let i = 0; i < 8; i++) {
-				tmp.copy(pts[i]).project(state.camera);
-				minX = Math.min(minX, tmp.x);
-				maxX = Math.max(maxX, tmp.x);
-				minY = Math.min(minY, tmp.y);
-				maxY = Math.max(maxY, tmp.y);
-			}
-
-			const cx = (minX + maxX) * 0.5 + 0.5;
-			const cy = (minY + maxY) * 0.5 + 0.5;
-			const hx = (maxX - minX) * 0.5;
-			const hy = (maxY - minY) * 0.5;
-
 			const dpr = state.gl.getPixelRatio();
 			u.uTime.value += delta;
 			u.uScene.value = fbo.texture;
@@ -435,15 +403,7 @@ function HeroScene({
 			u.uBaseAmp.value = 0.013;
 			u.uBaseScale.value = 1.18;
 
-			u.uHeroCenter.value.set(
-				THREE.MathUtils.clamp(cx, 0.0, 1.0),
-				THREE.MathUtils.clamp(cy, 0.0, 1.0),
-			);
-			u.uHeroSize.value.set(
-				THREE.MathUtils.clamp(hx + 0.15, 0.0, 0.8),
-				THREE.MathUtils.clamp(hy + 0.15, 0.0, 0.8),
-			);
-			u.uHeroRadius.value = 0.06;
+			// uHeroCenter / uHeroSize / uHeroRadius はシェーダーが参照していないため更新しない
 			u.uChromAb.value = 0.0;
 			// 一時的にデバッグモードを有効化
 			u.uShowMask.value = 0; // 0: エフェクト表示, 1: デバッグ表示


### PR DESCRIPTION
## 概要

トップページの液体エフェクトから、結果に寄与していない計算を2つ取り除きます。**どちらも出力が数学的に変わらない変更**で、見た目は一切変わりません。

## 1. ポインター由来の変位を局所化（GPU）

`disp` の各項は `bulge`（= `mask` を掛けた値）、`mask`、`ghost` のいずれかに掛かります。つまり **`mask` も `ghost` も 0 の画素では `disp` は厳密に 0** になり、そこで計算していた `fbm` 2回（= `noise` 6回 = `hash` 24回）は結果に一切寄与していませんでした。

```glsl
vec2 disp = vec2(0.0);
if (mask > 0.0 || ghost > 0.0) {
    // fbm 2回
    ...
}
```

効く場面は2つあります。

- **マウス停止時**: `mask` には `uIntensity` が掛かっており、マウスを止めると約0.56秒で 0 に減衰します。つまり**全画面**でスキップされます
- **マウス移動時**: 影響半径は `uRadius`(0.095) + `uFalloff`(0.165) 程度なので、**画面の大半**でスキップされます

1画素あたりの `fbm` は 6回 → 4回になります（残る4回は全画面に掛かるベースのゆらぎで、これは今回触っていません）。

## 2. 誰も読まない毎フレーム計算の撤去（CPU）

シェーダー側はこう書かれています。

```glsl
float heroMask = 1.0; // roundRectMask(uv, uHeroCenter, uHeroSize, uHeroRadius);
```

`uHeroCenter` / `uHeroSize` / `uHeroRadius` は**呼び出しごとコメントアウトされていて使われていません**。にもかかわらず JS 側では毎フレーム、

- 三角形グループとカードグループに対して `Box3.expandByObject`（サブツリー全体を走査してバウンディングボックスを再計算）
- その結果の8頂点をカメラへ射影

を実行していました。**結果を誰も読まない計算**です。カードのジオメトリは32×21分割の湾曲プレーン×3枚なので、走査対象は小さくありません。

この計算と、専用のワーク変数（`box` / `tmp` / `corners`）を削除しました。領域限定を復活させる場合は、シェーダー側の `heroMask` を戻したうえでここも戻す必要がある旨をコメントに残しています。

## 効果について（正確に）

**確実に言えること**: 結果に寄与していない計算が2種類、実際に実行されなくなりました。GPU 側は「1画素あたり `fbm` 6回 → 4回（大半の画素・大半の時間）」、CPU 側は「毎フレームのバウンディングボックス走査 → なし」です。

**言えないこと**: 実測はしていません。上記は計算量の見積もりです。

**体感差**: 開発環境（M4 Mac）では変更前から余裕があるため、フレームレートには現れません。効くのは GPU / CPU に余力のない環境です。

## 動作確認

`pnpm lint` エラー0件、`pnpm build` 成功。ローカルで目視確認済みです（液体の揺れ、マウス追従、ベースのゆらぎ、カードホバー、表示異常なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6djVvQHsEfUNoXSZc43n