### PR TITLE
release: SEOの配線ミス修正（canonical・内部リンク・Googlebotのレンダリング）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ public/models/*.fbx
 
 # 計測用ビルドの出力先（dev サーバーと .next を取り合わないため）
 .next-measure/
+# 検証用ビルドの出力先（doc/progress.md の検証手順で使う）。
+# ここを無視しないと biome が成果物まで lint/format しに行く
+.next-verify/

--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import MissionSection, { type MissionSidebarHandle } from "./MissionSection";
 
 // ssr: false にしないこと。グローバルメニューはトップページから配下ページへの
@@ -159,13 +160,18 @@ export default function HomeClient() {
 			}
 
 			if (hash === "") {
-				window.scrollTo({ top: 0, behavior: "smooth" });
+				// smooth だと 1000vh を延々とスクロールすることになり、その間ずっと
+				// 平滑化ループが追従を続けるため、CONTACT のように最下部から呼ぶと
+				// 先頭に着かない。auto で瞬時に飛ばし、直後に補間値を実位置へ揃える
+				// （doc/progress.md の「scrollTo の直後は必ず syncScrollLerp」に従う）。
+				window.scrollTo({ top: 0, behavior: "auto" });
+				syncScrollLerp();
 				return;
 			}
 
 			navigateToHash(hash);
 		},
-		[navigateToHash],
+		[navigateToHash, syncScrollLerp],
 	);
 
 	// 経路1: 初回ロード。他ページ（LPのCTAやグローバルナビ）から /#contact 等で来た場合
@@ -266,18 +272,16 @@ export default function HomeClient() {
 			const isCircleExpanded = scrolled >= CIRCLE_SCROLL_END;
 
 			// --- Text 1 Animation ("WEBの困りごとに...") ---
-			// Timing Shifted Later & Smoothed
-			// Desktop: In 8-15%, Out 22-28%
-			// Mobile: In 3-10%, Out 17-23% (Earlier to reduce scroll)
-			// Multiplier ~14 (1/0.07) for 7% range
-			const text1Start = isMobile ? 0.03 : 0.08;
+			// ファーストビューのコピーは最初から表示する（フェードインさせない）。
+			// 以前は 8%（PC）/ 3%（スマホ）スクロールしてから現れる設定で、
+			// スクロール0では opacity 0 だった。Googlebot はスクロールしないため、
+			// レンダリング結果が可視テキスト0文字の真っ黒な画面になっていた
+			// （3Dは WebGL なので Googlebot の環境では描画されない）。
+			// フェードアウト側のタイミングは変更していないので、スクロール後の演出は従来どおり。
+			// Desktop: Out 22-28% / Mobile: Out 17-23%
 			const text1End = isMobile ? 0.23 : 0.28;
-			const text1FadeIn = Math.max(
-				0,
-				Math.min(1, (scrolled - text1Start) * 14),
-			);
 			const text1FadeOut = Math.max(0, Math.min(1, (text1End - scrolled) * 16));
-			const text1Opacity = Math.min(text1FadeIn, text1FadeOut);
+			const text1Opacity = text1FadeOut;
 
 			if (text1Ref.current) {
 				const opacity = isCircleExpanded ? 0 : text1Opacity;
@@ -356,10 +360,23 @@ export default function HomeClient() {
 
 	return (
 		<main>
-			{/* 屋号を左上に固定配置 */}
-			<div className="fixed top-8 left-6 md:left-8 z-10 h-[50px]">
+			{/* 屋号を左上に固定配置。クリックでページ先頭へ戻る。
+			    h1 の pointer-events-none は背後の3Dがマウス操作を受け取れるようにするための指定。
+			    リンクにだけ pointer-events-auto を付けて、文字の上だけクリックできるようにしている。 */}
+			<div className="fixed top-8 left-6 md:left-8 z-30 h-[50px]">
 				<h1 className="text-2xl md:text-[28px] font-bold text-white pointer-events-none">
-					TANEBI CREATIVE
+					<Link
+						href="/"
+						onClick={(e) => {
+							// トップページ上ではブラウザ遷移させず、既存のスナップ処理で先頭へ戻す
+							e.preventDefault();
+							handleNavigate("/");
+						}}
+						className="pointer-events-auto inline-block transition-opacity duration-200 hover:opacity-70"
+						aria-label="ページの先頭に戻る"
+					>
+						TANEBI CREATIVE
+					</Link>
 				</h1>
 			</div>
 

--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -5,9 +5,12 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import dynamic from "next/dynamic";
 import MissionSection, { type MissionSidebarHandle } from "./MissionSection";
 
-const SidebarMenu = dynamic(
-	() => import("@/components/ui/sidebar-menu").then((mod) => mod.SidebarMenu),
-	{ ssr: false },
+// ssr: false にしないこと。グローバルメニューはトップページから配下ページへの
+// 唯一の内部リンク経路で、ssr: false だとリンクが初期HTMLに1本も出力されない。
+// SidebarMenu が window を触るのは useEffect の中だけなので SSR しても安全。
+// dynamic のままなのはコード分割の維持が目的。
+const SidebarMenu = dynamic(() =>
+	import("@/components/ui/sidebar-menu").then((mod) => mod.SidebarMenu),
 );
 import ContactSection from "./ContactSection";
 import { useHeroState } from "@/contexts/HeroStateContext";

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,13 +1,24 @@
+import type { Metadata } from "next";
 import Link from "next/link";
+
+// metadata が無いとルートの robots（index, follow）と canonical（トップページ）を
+// 継承し、Next.js が not-found に自動付与する noindex と矛盾したシグナルになる。
+// canonical: null で「トップの正規版である」という誤った主張も打ち消す。
+export const metadata: Metadata = {
+	title: "ページが見つかりません",
+	robots: { index: false, follow: false },
+	alternates: { canonical: null },
+};
 
 export default function NotFound() {
 	return (
 		<div className="fixed inset-0 bg-black">
 			<div className="absolute inset-0 flex flex-col items-center justify-center">
 				<div className="text-center space-y-8 px-4">
-					<h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+					{/* 屋号は見出しにしない。h2 が h1 より先に出て順序が逆転するため */}
+					<p className="text-2xl md:text-3xl font-bold text-white mb-4">
 						TANEBI CREATIVE
-					</h2>
+					</p>
 
 					<h1 className="text-6xl md:text-8xl font-bold text-white tracking-wider">
 						404

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,104 +1,21 @@
+import type { Metadata } from "next";
 import HeroCanvasSection from "@/components/three/HeroCanvasSection";
+import { generateSiteJsonLd, serializeJsonLd, SITE_CONFIG } from "@/lib/seo";
 import HomeClient from "./components/HomeClient";
+
+// canonical はルートレイアウトから継承させず、各ページで自分自身を指す（seo.ts のコメント参照）
+export const metadata: Metadata = {
+	alternates: { canonical: SITE_CONFIG.url },
+};
 
 export default function Home() {
 	return (
 		<HeroCanvasSection>
 			<script
 				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD（< はエスケープ済み）
 				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@graph": [
-							{
-								"@type": ["ProfessionalService", "LocalBusiness"],
-								"@id": "https://tanebi-net.com/#organization",
-								name: "TANEBI CREATIVE（タネビ クリエイティブ）- 奥州市のAI事業者",
-								alternateName: [
-									"タネビ クリエイティブ",
-									"TANEBI CREATIVE",
-									"奥州市 AI事業者",
-								],
-								url: "https://tanebi-net.com",
-								image: "https://tanebi-net.com/images/ogp.jpg",
-								description:
-									"岩手県奥州市を拠点に、AIを活用した業務改善やDX推進、Webサイト・ECサイト制作、アプリ開発を行っています。地域の中小企業がデジタルを実務で活かせるよう支援します。",
-								slogan:
-									"種から形へ、種火を力に。技術と対話で、事業の前進を支援します。",
-								address: {
-									"@type": "PostalAddress",
-									addressRegion: "岩手県",
-									addressLocality: "奥州市",
-									addressCountry: "JP",
-								},
-								geo: {
-									"@type": "GeoCoordinates",
-									latitude: 39.1448,
-									longitude: 141.1391,
-								},
-								areaServed: [
-									{
-										"@type": "AdministrativeArea",
-										name: "岩手県",
-									},
-								],
-								knowsAbout: [
-									"AI事業者",
-									"AI導入支援",
-									"AI活用コンサルティング",
-									"SEO（AIO/LLMO を含む生成AI時代の検索最適化）",
-									"構造化データ・コンテンツ設計",
-									"岩手県内の中小企業向けDX・業務効率化支援",
-									"AIを活用した集客・Webサイト制作",
-									"AIによる事務作業の自動化",
-									"社内情報の整理・ナレッジ共有の仕組み作り",
-								],
-								contactPoint: {
-									"@type": "ContactPoint",
-									contactType: "customer support",
-									url: "https://tanebi-net.com/contact",
-								},
-							},
-							{
-								"@type": "WebSite",
-								"@id": "https://tanebi-net.com/#website",
-								url: "https://tanebi-net.com",
-								name: "TANEBI CREATIVE | 岩手・奥州のWeb開発・AI活用・DX支援",
-								publisher: {
-									"@id": "https://tanebi-net.com/#organization",
-								},
-							},
-							{
-								"@type": "Service",
-								"@id": "https://tanebi-net.com/#service-web",
-								name: "Web制作（SEO/AIO 対応）",
-								provider: {
-									"@id": "https://tanebi-net.com/#organization",
-								},
-								description:
-									"SEO（AIO/LLMO を含む）の基本に忠実な高品質なWebサイト制作。人間への訴求力と、検索エンジン・生成AIへの可読性を両立します。",
-								areaServed: {
-									"@type": "AdministrativeArea",
-									name: "岩手県",
-								},
-							},
-							{
-								"@type": "Service",
-								"@id": "https://tanebi-net.com/#service-dx",
-								name: "AI実務活用・DX支援・SEO対応",
-								provider: {
-									"@id": "https://tanebi-net.com/#organization",
-								},
-								description:
-									"AI活用による業務効率化・DX推進サポート。LLM 活用（LLMO）の観点も含めた社内ナレッジの整理と活用を支援します。",
-								areaServed: {
-									"@type": "AdministrativeArea",
-									name: "岩手県",
-								},
-							},
-						],
-					}),
+					__html: serializeJsonLd(generateSiteJsonLd()),
 				}}
 			/>
 			{/* クライアント側のUIロジックをHomeClientに委譲 */}

--- a/src/app/service/issues/page.tsx
+++ b/src/app/service/issues/page.tsx
@@ -15,14 +15,26 @@ import { CtaBlock } from "@/components/lp/CtaBlock";
 import { anton, notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
-import { SITE_CONFIG } from "@/lib/seo";
+import {
+	buildPageSocialMetadata,
+	generateBreadcrumbJsonLd,
+	serializeJsonLd,
+	SITE_CONFIG,
+} from "@/lib/seo";
+
+const ISSUES_DESCRIPTION =
+	"ホームページを作って終わりにしない改善、ネット販売の立て直し、社内業務のツール化、増えすぎたツール費用の見直し、社内でAIを使える状態にすること。「こうしたい」から一緒に進めます。初回相談は無料です。";
 
 export const metadata: Metadata = {
 	// 屋号は seo.ts の title.template が付けるのでここには書かない
 	title: "その課題、ここから伸ばせます",
 	alternates: { canonical: `${SITE_CONFIG.url}/service/issues` },
-	description:
-		"ホームページを作って終わりにしない改善、ネット販売の立て直し、社内業務のツール化、増えすぎたツール費用の見直し、社内でAIを使える状態にすること。「こうしたい」から一緒に進めます。初回相談は無料です。",
+	description: ISSUES_DESCRIPTION,
+	...buildPageSocialMetadata({
+		title: "その課題、ここから伸ばせます | TANEBI CREATIVE",
+		description: ISSUES_DESCRIPTION,
+		path: "/service/issues",
+	}),
 };
 
 /** menuLabel / menuHref は /service の該当メニューへの送り先。見出しの文言も向こうに揃える */
@@ -131,8 +143,19 @@ const approaches = [
 ];
 
 export default function ServiceIssuesPage() {
+	const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+		{ name: "ホーム", path: "/" },
+		{ name: "できること ─ ご相談メニュー", path: "/service" },
+		{ name: "その課題、ここから伸ばせます", path: "/service/issues" },
+	]);
+
 	return (
 		<div className={`${notoSansJp.className} container mx-auto max-w-5xl px-4`}>
+			<script
+				type="application/ld+json"
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD（< はエスケープ済み）
+				dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+			/>
 			<PageHero
 				label="From issue to growth"
 				english="Issues"

--- a/src/app/service/issues/page.tsx
+++ b/src/app/service/issues/page.tsx
@@ -15,9 +15,12 @@ import { CtaBlock } from "@/components/lp/CtaBlock";
 import { anton, notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
+import { SITE_CONFIG } from "@/lib/seo";
 
 export const metadata: Metadata = {
-	title: "その課題、ここから伸ばせます | TANEBI CREATIVE",
+	// 屋号は seo.ts の title.template が付けるのでここには書かない
+	title: "その課題、ここから伸ばせます",
+	alternates: { canonical: `${SITE_CONFIG.url}/service/issues` },
 	description:
 		"ホームページを作って終わりにしない改善、ネット販売の立て直し、社内業務のツール化、増えすぎたツール費用の見直し、社内でAIを使える状態にすること。「こうしたい」から一緒に進めます。初回相談は無料です。",
 };

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -13,9 +13,12 @@ import { anton, notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
 import { ExampleListAccordion } from "./components/example-list-accordion";
+import { SITE_CONFIG } from "@/lib/seo";
 
 export const metadata: Metadata = {
-	title: "できること ─ ご相談メニュー | TANEBI CREATIVE",
+	// 屋号は seo.ts の title.template が付けるのでここには書かない
+	title: "できること ─ ご相談メニュー",
+	alternates: { canonical: `${SITE_CONFIG.url}/service` },
 	description:
 		"問い合わせを取りこぼさないWebサイトの制作・改善、AI活用の相談、業務ツールの開発。受け取ったあとの社内の流れまで含めて設計します。どれも「まず話を聞いてから」始められます。初回相談は無料です。",
 };

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -13,14 +13,27 @@ import { anton, notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
 import { ExampleListAccordion } from "./components/example-list-accordion";
-import { SITE_CONFIG } from "@/lib/seo";
+import {
+	generateBreadcrumbJsonLd,
+	generateServiceCatalogJsonLd,
+	buildPageSocialMetadata,
+	serializeJsonLd,
+	SITE_CONFIG,
+} from "@/lib/seo";
+
+const SERVICE_DESCRIPTION =
+	"問い合わせを取りこぼさないWebサイトの制作・改善、AI活用の相談、業務ツールの開発。受け取ったあとの社内の流れまで含めて設計します。どれも「まず話を聞いてから」始められます。初回相談は無料です。";
 
 export const metadata: Metadata = {
 	// 屋号は seo.ts の title.template が付けるのでここには書かない
 	title: "できること ─ ご相談メニュー",
 	alternates: { canonical: `${SITE_CONFIG.url}/service` },
-	description:
-		"問い合わせを取りこぼさないWebサイトの制作・改善、AI活用の相談、業務ツールの開発。受け取ったあとの社内の流れまで含めて設計します。どれも「まず話を聞いてから」始められます。初回相談は無料です。",
+	description: SERVICE_DESCRIPTION,
+	...buildPageSocialMetadata({
+		title: "できること ─ ご相談メニュー | TANEBI CREATIVE",
+		description: SERVICE_DESCRIPTION,
+		path: "/service",
+	}),
 };
 
 type Menu = {
@@ -152,8 +165,32 @@ const steps = [
 ];
 
 export default function ServicePage() {
+	// 構造化データ。name / description はページ本文と対応させること
+	// （ページに書いていない内容をマークアップしない）。
+	const jsonLd = [
+		generateBreadcrumbJsonLd([
+			{ name: "ホーム", path: "/" },
+			{ name: "できること ─ ご相談メニュー", path: "/service" },
+		]),
+		generateServiceCatalogJsonLd(
+			menus.map((menu) => ({
+				id: menu.id,
+				name: menu.title,
+				description: menu.body[0],
+			})),
+		),
+	];
+
 	return (
 		<div className={`${notoSansJp.className} container mx-auto max-w-5xl px-4`}>
+			{jsonLd.map((data) => (
+				<script
+					key={String(data["@type"] ?? data["@graph"])}
+					type="application/ld+json"
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD（< はエスケープ済み）
+					dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+				/>
+			))}
 			<PageHero
 				label="What we can do"
 				english="Service"

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,23 +4,27 @@ import { getBlogPosts } from "@/lib/microcms";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://tanebi-net.com";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	// 静的ページ
+	// 静的ページ。
+	// lastModified に new Date()（＝ビルド時刻）を使わないこと。
+	// 中身を変えていないページまで毎デプロイ「更新した」と申告することになり、
+	// クローラから見た更新日の信頼性が落ちる。
+	// ページの内容を実際に書き換えたときに、ここの日付も更新すること。
 	const staticPages: MetadataRoute.Sitemap = [
 		{
 			url: SITE_URL,
-			lastModified: new Date(),
-			changeFrequency: "weekly",
+			lastModified: new Date("2026-09-06"),
+			changeFrequency: "monthly",
 			priority: 1,
 		},
 		{
 			url: `${SITE_URL}/service`,
-			lastModified: new Date(),
+			lastModified: new Date("2026-08-15"),
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${SITE_URL}/service/issues`,
-			lastModified: new Date(),
+			lastModified: new Date("2026-08-15"),
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -3,14 +3,21 @@ import { CtaBlock } from "@/components/lp/CtaBlock";
 import { notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
-import { SITE_CONFIG } from "@/lib/seo";
+import { buildPageSocialMetadata, SITE_CONFIG } from "@/lib/seo";
+
+const WORKS_DESCRIPTION =
+	"待機確認の業務を自作のWebツールに置き換え、今も毎日使っています。何に困り、何を整理し、どう作ったか。小さく作って使いながら育てる進め方を紹介します。";
 
 export const metadata: Metadata = {
 	// 屋号は seo.ts の title.template が付けるのでここには書かない
 	title: "実際の取り組み ─ 自社の業務を、自作ツールで改善した話",
 	alternates: { canonical: `${SITE_CONFIG.url}/works` },
-	description:
-		"待機確認の業務を自作のWebツールに置き換え、今も毎日使っています。何に困り、何を整理し、どう作ったか。小さく作って使いながら育てる進め方を紹介します。",
+	description: WORKS_DESCRIPTION,
+	...buildPageSocialMetadata({
+		title: "実際の取り組み | TANEBI CREATIVE",
+		description: WORKS_DESCRIPTION,
+		path: "/works",
+	}),
 	// ページ再設計中のため検索エンジンには載せない（再公開時にこの robots を削除する）
 	robots: { index: false, follow: false },
 };

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -3,10 +3,12 @@ import { CtaBlock } from "@/components/lp/CtaBlock";
 import { notoSansJp } from "@/components/lp/fonts";
 import { LpSection } from "@/components/lp/LpSection";
 import { PageHero } from "@/components/lp/PageHero";
+import { SITE_CONFIG } from "@/lib/seo";
 
 export const metadata: Metadata = {
-	title:
-		"実際の取り組み ─ 自社の業務を、自作ツールで改善した話 | TANEBI CREATIVE",
+	// 屋号は seo.ts の title.template が付けるのでここには書かない
+	title: "実際の取り組み ─ 自社の業務を、自作ツールで改善した話",
+	alternates: { canonical: `${SITE_CONFIG.url}/works` },
 	description:
 		"待機確認の業務を自作のWebツールに置き換え、今も毎日使っています。何に困り、何を整理し、どう作ったか。小さく作って使いながら育てる進め方を紹介します。",
 	// ページ再設計中のため検索エンジンには載せない（再公開時にこの robots を削除する）

--- a/src/components/loading/LoadingScreen.tsx
+++ b/src/components/loading/LoadingScreen.tsx
@@ -62,14 +62,18 @@ export default function LoadingScreen({
 		>
 			{/* ローディングUI */}
 			<div className="absolute inset-0 flex flex-col items-center justify-center">
-				<div className="text-center space-y-8 px-4">
-					<h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+				{/* ここは見出し要素にしないこと。
+				    ローディング画面はトップページの初期HTMLに含まれるため、h1 を置くと
+				    文書順で最初の h1 が「LOADING」になり、HomeClient 側の h1 と合わせて
+				    1ページに h1 が2つある状態になる（h2 → h1 の順序逆転も起きていた）。 */}
+				<div className="text-center space-y-8 px-4" aria-hidden="true">
+					<p className="text-2xl md:text-3xl font-bold text-white mb-4">
 						TANEBI CREATIVE
-					</h2>
+					</p>
 
-					<h1 className="text-xl md:text-2xl font-bold text-white tracking-wider animate-pulse">
+					<p className="text-xl md:text-2xl font-bold text-white tracking-wider animate-pulse">
 						LOADING
-					</h1>
+					</p>
 
 					<div className="w-64 md:w-96 mx-auto">
 						<div className="h-2 bg-gray-800 rounded-full overflow-hidden">

--- a/src/components/lp/LpLightScope.tsx
+++ b/src/components/lp/LpLightScope.tsx
@@ -7,9 +7,10 @@ import type { ReactNode } from "react";
 // onNavigate は渡さない。LP上ではトップページ内セクションへのリンクは
 // 通常のリンク（/#hash）としてナビゲートすればよく、トップページ限定のスムーズスクロール
 // インターセプトは不要なため（sidebar-menu.tsx 側で onNavigate 有無により分岐している）。
-const SidebarMenu = dynamic(
-	() => import("@/components/ui/sidebar-menu").then((mod) => mod.SidebarMenu),
-	{ ssr: false },
+// ssr: false にしないこと（HomeClient 側と同じ理由）。メニュー内のリンクが
+// 初期HTMLに出力されなくなり、クローラがページ間を辿れなくなる。
+const SidebarMenu = dynamic(() =>
+	import("@/components/ui/sidebar-menu").then((mod) => mod.SidebarMenu),
 );
 
 /**

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import {
 	Menu,
 	X,
@@ -12,6 +12,7 @@ import {
 	Bird,
 	Wrench,
 	Lightbulb,
+	Newspaper,
 } from "lucide-react";
 import gsap from "gsap";
 import { markHashJump } from "@/lib/hash-jump";
@@ -65,6 +66,12 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 			label: "ABOUT",
 			icon: User,
 			description: "TANEBI CREATIVEについて",
+		},
+		{
+			href: "/blog",
+			label: "BLOG",
+			icon: Newspaper,
+			description: "技術やお役立ち情報の発信",
 		},
 		{
 			href: "/#contact",
@@ -215,60 +222,77 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 				</div>
 			</button>
 
-			{/* Expanded Overlay & Menu Content */}
-			<AnimatePresence>
-				{isOpen && (
-					<>
-						{/* Backdrop */}
-						<motion.div
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							exit={{ opacity: 0 }}
-							onClick={toggleMenu}
-							className="fixed inset-0 bg-black/40 z-40 backdrop-blur-[2px] pointer-events-auto"
-						/>
+			{/* Expanded Overlay & Menu Content
 
-						{/* Menu Content Container */}
-						{/* pb-28 は ChatWidget の UFOボタン(bottom-6 right-6, 64px四方)との衝突を避けるための下部クリアランス。
+			    条件マウント（{isOpen && ...}）にはせず、常に DOM に置いて visibility で出し分ける。
+			    条件マウントだとメニュー内の <Link> が初期HTMLにもレンダリング後のDOMにも存在せず、
+			    トップページから配下ページへの内部リンクが1本も無い状態になる（Googlebot は
+			    クリックしないので、JSを実行してもハンバーガー内のリンクには到達できない）。
+			    visibility:hidden は要素をフォーカス対象からも外すため、閉じている間の
+			    キーボード操作でリンクを踏んでしまうこともない。 */}
+			{/* Backdrop */}
+			<motion.div
+				initial={false}
+				animate={{ opacity: isOpen ? 1 : 0 }}
+				onClick={toggleMenu}
+				className={`fixed inset-0 bg-black/40 z-40 backdrop-blur-[2px] ${
+					isOpen ? "pointer-events-auto" : "pointer-events-none"
+				}`}
+			/>
+
+			{/* Menu Content Container */}
+			{/* pb-28 は ChatWidget の UFOボタン(bottom-6 right-6, 64px四方)との衝突を避けるための下部クリアランス。
 						    overflow-y-auto は項目数が増えた場合の保険（100dvh に収まらなくても隠れずスクロールできる）。
 						    md:p-12 は使わない。PCもSPと同じ2rem(p-8)にする（devtoolsでの確認・指示どおり） */}
-						<div
-							className="fixed top-0 right-0 w-full max-w-[450px] z-50 flex flex-col overflow-y-auto p-8 pb-28 pointer-events-auto"
-							style={{ height: "100dvh" }} // モバイルアドレスバー対応
-						>
-							{/* Close Button Area
+			<motion.div
+				// inert は React 19 のネイティブ属性。閉じている間はこの subtree 全体が
+				// フォーカス・ヒットテスト・支援技術の対象から外れる（DOM には残るので
+				// クローラからは見える）。visibility の transitionEnd に頼ると初回
+				// レンダリングで適用されるか不確実なため、こちらで決定的に制御する。
+				inert={!isOpen}
+				initial={false}
+				animate={{ opacity: isOpen ? 1 : 0 }}
+				transition={{ duration: 0.25 }}
+				className={`fixed top-0 right-0 w-full max-w-[450px] z-50 flex flex-col overflow-y-auto p-8 pb-28 ${
+					isOpen ? "pointer-events-auto" : "pointer-events-none"
+				}`}
+				style={{ height: "100dvh" }} // モバイルアドレスバー対応
+			>
+				{/* Close Button Area
 							    top-8 right-2 は SP(position:absolute)用。md:static になるPCでは
 							    position:static のため top/right は効かない。PC側の余白は md:mb-12 が
 							    作っていたが不要とのことなので削除した */}
-							<div className="absolute top-8 right-2 w-[50px] h-[50px] flex items-center justify-center z-50 md:static md:w-full md:h-auto md:block md:text-right">
-								<button
-									onClick={handleClose}
-									className="p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors text-white"
-									type="button"
-									aria-label="Close menu"
-								>
-									<motion.div
-										animate={{ rotate: isClosing ? 90 : 0 }}
-										transition={{ duration: 0.4, ease: "easeInOut" }}
-									>
-										<X className="w-8 h-8" strokeWidth={1.5} />
-									</motion.div>
-								</button>
-							</div>
+				<div className="absolute top-8 right-2 w-[50px] h-[50px] flex items-center justify-center z-50 md:static md:w-full md:h-auto md:block md:text-right">
+					<button
+						onClick={handleClose}
+						className="p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors text-white"
+						type="button"
+						aria-label="Close menu"
+					>
+						<motion.div
+							animate={{ rotate: isClosing ? 90 : 0 }}
+							transition={{ duration: 0.4, ease: "easeInOut" }}
+						>
+							<X className="w-8 h-8" strokeWidth={1.5} />
+						</motion.div>
+					</button>
+				</div>
 
-							{/* SP・PCとも上下左右中央寄せ。
+				{/* SP・PCとも上下左右中央寄せ。
 						    justify-center は内容が溢れると上端が見切れて到達できなくなる懸念があるが、
 						    nav は flex-1（min-height:auto）なので内容が多い場合は nav 自体が伸び、
 						    親コンテナ側の overflow-y-auto によるスクロールになる。よって見切れは起きない。
 						    CONTACTとUFOボタン(ChatWidget)の衝突は Menu Content Container の
 						    pb-28（下部クリアランス）で対処している。
 						    PCの項目間隔(gap)は画面の高さに応じて可変（詳細はitem labelのコメント参照） */}
-							<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh,1.5rem)] flex-1 justify-center items-center w-full">
-								{menuItems.map((item, i) => (
-									<motion.div
-										key={item.href}
-										initial={{ x: 50, opacity: 0 }}
-										animate={{
+				<nav className="flex flex-col space-y-4 md:space-y-[clamp(0.5rem,2dvh,1.5rem)] flex-1 justify-center items-center w-full">
+					{menuItems.map((item, i) => (
+						<motion.div
+							key={item.href}
+							initial={false}
+							animate={
+								isOpen
+									? {
 											x: 0,
 											opacity: 1,
 											transition: {
@@ -276,60 +300,61 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 												type: "spring",
 												stiffness: 100,
 											},
-										}}
-										exit={{
+										}
+									: {
 											x: 50,
 											opacity: 0,
 											transition: { delay: 0, duration: 0.2 },
-										}}
-										className="w-full"
-									>
-										<Link
-											href={item.href}
-											onClick={(e) => {
-												if (onNavigate) {
-													// トップページ上でのみ、これらはスムーズスクロールにインターセプトする。
-													// onNavigate 側は従来どおり /about 等の非ハッシュ形式で判定しているため、
-													// ここで # を外してから渡す（LP側の href 自体はハッシュ形式のまま維持する）
-													const topPageTargets = [
-														"/",
-														"/#mission",
-														"/#about",
-														"/#contact",
-													];
-													if (topPageTargets.includes(item.href)) {
-														e.preventDefault();
-														onNavigate(item.href.replace(/^\/#/, "/"));
-													}
-												} else if (item.href.startsWith("/#")) {
-													// LP等の別ページからハッシュ付きでトップへ遷移するとき、
-													// HomeClient が初回レンダリングから黒カバーを出せるように
-													// フラグを立てる（スナップ完了までの中間状態を見せないため）
-													markHashJump();
-												}
-												setIsOpen(false);
-											}}
-											className="group relative block w-full md:w-[400px]"
-										>
-											{/* Desktop Hover Card: White Background, Icon Pops Up */}
-											{/* md:py-[clamp(...)] は p-6 の上下だけを打ち消す指定。
+										}
+							}
+							className="w-full"
+						>
+							<Link
+								href={item.href}
+								onClick={(e) => {
+									if (onNavigate) {
+										// トップページ上でのみ、これらはスムーズスクロールにインターセプトする。
+										// onNavigate 側は従来どおり /about 等の非ハッシュ形式で判定しているため、
+										// ここで # を外してから渡す（LP側の href 自体はハッシュ形式のまま維持する）
+										const topPageTargets = [
+											"/",
+											"/#mission",
+											"/#about",
+											"/#contact",
+										];
+										if (topPageTargets.includes(item.href)) {
+											e.preventDefault();
+											onNavigate(item.href.replace(/^\/#/, "/"));
+										}
+									} else if (item.href.startsWith("/#")) {
+										// LP等の別ページからハッシュ付きでトップへ遷移するとき、
+										// HomeClient が初回レンダリングから黒カバーを出せるように
+										// フラグを立てる（スナップ完了までの中間状態を見せないため）
+										markHashJump();
+									}
+									setIsOpen(false);
+								}}
+								className="group relative block w-full md:w-[400px]"
+							>
+								{/* Desktop Hover Card: White Background, Icon Pops Up */}
+								{/* md:py-[clamp(...)] は p-6 の上下だけを打ち消す指定。
 											    p-6(上下24pxずつ=1項目あたり48px)を6項目ぶん固定で積むと、
 											    ノートPC相当の画面高さ(800px前後)でメニューが画面内に収まらなくなるため、
 											    上下パディングも画面の高さに応じて可変にしている。左右のpaddingはp-6のまま */}
-											<div
-												className="
+								<div
+									className="
                                                 hidden md:flex flex-col items-center justify-center p-6 md:py-[clamp(0.375rem,1.5dvh,1.5rem)] rounded-xl transition-all duration-300
                                                 text-white
                                                 md:hover:text-[#60d5fa]
                                             "
-											>
-												{/* Icon: Pops up ("Nyutto") on hover */}
-												<div className="h-0 overflow-hidden md:group-hover:h-auto md:group-hover:mb-4 transition-all duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] opacity-0 md:group-hover:opacity-100 flex justify-center origin-bottom">
-													<item.icon className="w-10 h-10" strokeWidth={1.5} />
-												</div>
+								>
+									{/* Icon: Pops up ("Nyutto") on hover */}
+									<div className="h-0 overflow-hidden md:group-hover:h-auto md:group-hover:mb-4 transition-all duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] opacity-0 md:group-hover:opacity-100 flex justify-center origin-bottom">
+										<item.icon className="w-10 h-10" strokeWidth={1.5} />
+									</div>
 
-												{/* Label */}
-												{/* PC(md:)は画面の高さに応じて文字サイズが可変。項目が6個になり、低い画面高さでは
+									{/* Label */}
+									{/* PC(md:)は画面の高さに応じて文字サイズが可変。項目が6個になり、低い画面高さでは
 												    text-5xl(48px)固定だと下スクロールが発生しうるため、
 												    clamp(下限28px, 4dvh+16px, 上限48px=text-5xl相当) にした。
 												    画面高さ800px以上ではこれまで通り48pxのまま、低い画面だけ縮んで
@@ -338,41 +363,41 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 												    セットで定義されるが、text-[clamp(...)] のようなアービトラリ値は font-size しか
 												    指定されず、html の line-height:1.5 を継承してしまう（48px想定が実際72pxになり、
 												    計算上収まるはずの高さでも下スクロールが発生していた） */}
-												<span className="text-4xl md:text-[clamp(1.75rem,5dvh,3rem)] md:leading-none font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
-													{item.label}
-												</span>
+									<span className="text-4xl md:text-[clamp(1.75rem,5dvh,3rem)] md:leading-none font-bold tracking-wider font-sans md:group-hover:mb-2 transition-all duration-300">
+										{item.label}
+									</span>
 
-												{/* Description: Hidden by default, appears on hover */}
-												<div className="h-0 overflow-hidden md:group-hover:h-auto transition-all duration-300 opacity-0 md:group-hover:opacity-100">
-													<span className="text-sm font-bold tracking-wide">
-														{item.description}
-													</span>
-												</div>
-											</div>
+									{/* Description: Hidden by default, appears on hover */}
+									<div className="h-0 overflow-hidden md:group-hover:h-auto transition-all duration-300 opacity-0 md:group-hover:opacity-100">
+										<span className="text-sm font-bold tracking-wide">
+											{item.description}
+										</span>
+									</div>
+								</div>
 
-											{/* Mobile Styles (Visible on Mobile) */}
-											<div className="md:hidden text-center">
-												<span className="text-4xl font-bold text-white tracking-wider font-sans">
-													{item.label}
-												</span>
-											</div>
-										</Link>
-									</motion.div>
-								))}
-							</nav>
+								{/* Mobile Styles (Visible on Mobile) */}
+								<div className="md:hidden text-center">
+									<span className="text-4xl font-bold text-white tracking-wider font-sans">
+										{item.label}
+									</span>
+								</div>
+							</Link>
+						</motion.div>
+					))}
+				</nav>
 
-							<motion.div
-								className="mt-auto text-white/50 text-sm w-full text-center"
-								initial={{ opacity: 0 }}
-								animate={{ opacity: 1, transition: { delay: 0.8 } }}
-								exit={{ opacity: 0, transition: { duration: 0.2, delay: 0 } }}
-							>
-								<p>&copy; TANEBI CREATIVE</p>
-							</motion.div>
-						</div>
-					</>
-				)}
-			</AnimatePresence>
+				<motion.div
+					className="mt-auto text-white/50 text-sm w-full text-center"
+					initial={false}
+					animate={
+						isOpen
+							? { opacity: 1, transition: { delay: 0.8 } }
+							: { opacity: 0, transition: { duration: 0.2, delay: 0 } }
+					}
+				>
+					<p>&copy; TANEBI CREATIVE</p>
+				</motion.div>
+			</motion.div>
 		</>
 	);
 }

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -12,7 +12,6 @@ import {
 	Bird,
 	Wrench,
 	Lightbulb,
-	Newspaper,
 } from "lucide-react";
 import gsap from "gsap";
 import { markHashJump } from "@/lib/hash-jump";
@@ -66,12 +65,6 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 			label: "ABOUT",
 			icon: User,
 			description: "TANEBI CREATIVEについて",
-		},
-		{
-			href: "/blog",
-			label: "BLOG",
-			icon: Newspaper,
-			description: "技術やお役立ち情報の発信",
 		},
 		{
 			href: "/#contact",

--- a/src/components/ui/sidebar-menu.tsx
+++ b/src/components/ui/sidebar-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import {
 	Menu,
 	X,
@@ -223,15 +223,24 @@ export function SidebarMenu({ onNavigate }: SidebarMenuProps) {
 			    クリックしないので、JSを実行してもハンバーガー内のリンクには到達できない）。
 			    visibility:hidden は要素をフォーカス対象からも外すため、閉じている間の
 			    キーボード操作でリンクを踏んでしまうこともない。 */}
-			{/* Backdrop */}
-			<motion.div
-				initial={false}
-				animate={{ opacity: isOpen ? 1 : 0 }}
-				onClick={toggleMenu}
-				className={`fixed inset-0 bg-black/40 z-40 backdrop-blur-[2px] ${
-					isOpen ? "pointer-events-auto" : "pointer-events-none"
-				}`}
-			/>
+			{/* Backdrop
+			    これは常時マウントにしないこと。backdrop-filter は opacity 0 でも
+			    ビューポート全体に合成レイヤーを作るため、下にある3Dキャンバスや
+			    MissionSection(z-20) の描画が壊れる（ブラックホールが出ない・
+			    MISSIONがセクションごと点滅する、という症状が出た）。
+			    クローラに見せたいリンクは下のメニュー本体にあるので、
+			    背景だけ従来どおり開いている間だけ描画すれば足りる。 */}
+			<AnimatePresence>
+				{isOpen && (
+					<motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						onClick={toggleMenu}
+						className="fixed inset-0 bg-black/40 z-40 backdrop-blur-[2px] pointer-events-auto"
+					/>
+				)}
+			</AnimatePresence>
 
 			{/* Menu Content Container */}
 			{/* pb-28 は ChatWidget の UFOボタン(bottom-6 right-6, 64px四方)との衝突を避けるための下部クリアランス。

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -293,3 +293,85 @@ export function generateSiteJsonLd(): Record<string, unknown> {
 export function serializeJsonLd(jsonLd: Record<string, unknown>): string {
 	return JSON.stringify(jsonLd).replace(/</g, "\\u003c");
 }
+
+/**
+ * パンくずの構造化データ。`path` はサイトルートからの相対パス（先頭スラッシュ込み）。
+ * 末尾（現在地）まで含めて渡すこと。
+ */
+export function generateBreadcrumbJsonLd(
+	items: { name: string; path: string }[],
+): Record<string, unknown> {
+	return {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: items.map((item, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			name: item.name,
+			item: `${SITE_CONFIG.url}${item.path}`,
+		})),
+	};
+}
+
+/**
+ * /service の提供メニューの構造化データ。
+ * ページ上に実際に書かれている3メニュー（Web / AI / Tools）と対応させること。
+ * provider はトップページの Organization ノードを @id で参照する。
+ */
+export function generateServiceCatalogJsonLd(
+	services: { id: string; name: string; description: string }[],
+): Record<string, unknown> {
+	return {
+		"@context": "https://schema.org",
+		"@graph": services.map((service) => ({
+			"@type": "Service",
+			"@id": `${SITE_CONFIG.url}/service#${service.id}`,
+			name: service.name,
+			description: service.description,
+			provider: { "@id": `${SITE_CONFIG.url}/#organization` },
+			areaServed: { "@type": "AdministrativeArea", name: "岩手県" },
+		})),
+	};
+}
+
+/**
+ * 下層ページ用の openGraph / twitter を組み立てる。
+ *
+ * Next.js の Metadata は openGraph を「親とマージ」ではなく「丸ごと置換」するため、
+ * ページ側で openGraph を定義するときは images や siteName も必ず自前で持たせる必要がある。
+ * ここを通さないと、下層ページのOGPがトップページのもの（og:title / og:url がトップ）のままになる。
+ */
+export function buildPageSocialMetadata({
+	title,
+	description,
+	path,
+	image,
+}: {
+	title: string;
+	description: string;
+	/** サイトルートからの相対パス（先頭スラッシュ込み） */
+	path: string;
+	/** 未指定ならサイト共通のOGP画像 */
+	image?: string;
+}): Pick<Metadata, "openGraph" | "twitter"> {
+	const imageUrl = image ?? `${SITE_CONFIG.url}${SITE_CONFIG.ogImage}`;
+	return {
+		openGraph: {
+			type: "website",
+			locale: "ja_JP",
+			url: `${SITE_CONFIG.url}${path}`,
+			siteName: SITE_CONFIG.name,
+			title,
+			description,
+			images: [{ url: imageUrl, width: 1200, height: 630, alt: title }],
+		},
+		twitter: {
+			card: "summary_large_image",
+			site: SITE_CONFIG.twitterHandle,
+			creator: SITE_CONFIG.twitterHandle,
+			title,
+			description,
+			images: [imageUrl],
+		},
+	};
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 
 export const SITE_CONFIG = {
 	name: "TANEBI CREATIVE | 岩手・奥州のWeb開発・AI活用・DX支援",
+	/** title の template とパンくずに使う短い屋号。
+	 *  name をそのまま template に使うと下層ページの title が70文字超になり SERP で切れる。 */
+	shortName: "TANEBI CREATIVE",
 	description:
 		"岩手県奥州市を拠点に、AIを活用した業務改善やDX推進、Webサイト・ECサイト制作、アプリ開発を行っています。地域の中小企業がデジタルを実務で活かせるよう支援します。",
 	url: process.env.NEXT_PUBLIC_SITE_URL || "https://tanebi-net.com",
@@ -157,7 +160,9 @@ export const BLOG_LIST_METADATA: Metadata = {
 export const DEFAULT_METADATA: Metadata = {
 	title: {
 		default: SITE_CONFIG.name,
-		template: `%s | ${SITE_CONFIG.name}`,
+		// 各ページの title には屋号を書かないこと（ここで付与される）。
+		// 書くと「ページ名 | TANEBI CREATIVE | TANEBI CREATIVE | …」と二重になる。
+		template: `%s | ${SITE_CONFIG.shortName}`,
 	},
 	description: SITE_CONFIG.description,
 	keywords:
@@ -190,9 +195,10 @@ export const DEFAULT_METADATA: Metadata = {
 		index: true,
 		follow: true,
 	},
-	alternates: {
-		canonical: SITE_CONFIG.url,
-	},
+	// canonical はここに置かない。ルートレイアウトの metadata は子セグメントへ継承されるため、
+	// ここで canonical を指定すると alternates を上書きしていない全ページが
+	// 「正規版はトップページ」と自己申告してしまい、インデックスから外れる。
+	// 各ページで自分自身の URL を alternates.canonical に指定すること。
 	metadataBase: new URL(SITE_CONFIG.url),
 	icons: {
 		icon: "/images/favicon.png",
@@ -202,3 +208,88 @@ export const DEFAULT_METADATA: Metadata = {
 		google: "_MgYG4duuAQUZDGWyhM1a-HKF7WpTz_i8n-Qp9POXYw",
 	},
 };
+
+// サイト共通の構造化データ（JSON-LD / @graph）。トップページにのみ出力する。
+// `@id` は他ページの JSON-LD（BlogPosting の publisher など）から参照される安定IDなので変更しないこと。
+export function generateSiteJsonLd(): Record<string, unknown> {
+	const url = SITE_CONFIG.url;
+	return {
+		"@context": "https://schema.org",
+		"@graph": [
+			{
+				"@type": ["ProfessionalService", "LocalBusiness"],
+				"@id": `${url}/#organization`,
+				name: "TANEBI CREATIVE（タネビ クリエイティブ）- 奥州市のAI事業者",
+				alternateName: [
+					"タネビ クリエイティブ",
+					"TANEBI CREATIVE",
+					"奥州市 AI事業者",
+				],
+				url,
+				image: `${url}${SITE_CONFIG.ogImage}`,
+				description: SITE_CONFIG.description,
+				slogan:
+					"種から形へ、種火を力に。技術と対話で、事業の前進を支援します。",
+				address: {
+					"@type": "PostalAddress",
+					addressRegion: "岩手県",
+					addressLocality: "奥州市",
+					addressCountry: "JP",
+				},
+				geo: {
+					"@type": "GeoCoordinates",
+					latitude: 39.1448,
+					longitude: 141.1391,
+				},
+				areaServed: [{ "@type": "AdministrativeArea", name: "岩手県" }],
+				knowsAbout: [
+					"AI事業者",
+					"AI導入支援",
+					"AI活用コンサルティング",
+					"SEO（AIO/LLMO を含む生成AI時代の検索最適化）",
+					"構造化データ・コンテンツ設計",
+					"岩手県内の中小企業向けDX・業務効率化支援",
+					"AIを活用した集客・Webサイト制作",
+					"AIによる事務作業の自動化",
+					"社内情報の整理・ナレッジ共有の仕組み作り",
+				],
+				contactPoint: {
+					"@type": "ContactPoint",
+					contactType: "customer support",
+					// 問い合わせはトップpage内のセクション。/contact というルートは存在しない
+					url: `${url}/#contact`,
+				},
+			},
+			{
+				"@type": "WebSite",
+				"@id": `${url}/#website`,
+				url,
+				name: SITE_CONFIG.name,
+				publisher: { "@id": `${url}/#organization` },
+			},
+			{
+				"@type": "Service",
+				"@id": `${url}/#service-web`,
+				name: "Web制作（SEO/AIO 対応）",
+				provider: { "@id": `${url}/#organization` },
+				description:
+					"SEO（AIO/LLMO を含む）の基本に忠実な高品質なWebサイト制作。人間への訴求力と、検索エンジン・生成AIへの可読性を両立します。",
+				areaServed: { "@type": "AdministrativeArea", name: "岩手県" },
+			},
+			{
+				"@type": "Service",
+				"@id": `${url}/#service-dx`,
+				name: "AI実務活用・DX支援・SEO対応",
+				provider: { "@id": `${url}/#organization` },
+				description:
+					"AI活用による業務効率化・DX推進サポート。LLM 活用（LLMO）の観点も含めた社内ナレッジの整理と活用を支援します。",
+				areaServed: { "@type": "AdministrativeArea", name: "岩手県" },
+			},
+		],
+	};
+}
+
+/** JSON-LD を `<script>` に埋めるための文字列化。`</script>` ブレイクアウト対策として `<` をエスケープする。 */
+export function serializeJsonLd(jsonLd: Record<string, unknown>): string {
+	return JSON.stringify(jsonLd).replace(/</g, "\\u003c");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,10 +26,11 @@
 		"**/*.d.ts",
 		"**/*.ts",
 		"**/*.tsx",
+		".next-measure/types/**/*.ts",
 		".next/types/**/*.ts",
 		"next-env.d.ts",
 		"next.config.js",
-		".next-measure/types/**/*.ts"
+		".next-verify/types/**/*.ts"
 	],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 概要

SEO の配線ミス修正を本番へリリースする。PR #197（`dev`）の内容のみ。

順位を上げる施策ではなく、**正しく作ったものを自分で無効化していた状態を解く**修正が中心。

## リリース内容

### 検索結果に出るようになる（最重要）

**`/service`・`/service/issues`・`/works` の canonical がトップページを指していた。** `seo.ts` の `DEFAULT_METADATA.alternates.canonical` をルートレイアウト経由で全ページが継承し、各ページが「正規版はトップ」と自己申告していた。sitemap に登録して `index, follow` を出しているのに canonical で打ち消している状態で、本文2,448文字の主力ページが独立ページとして扱われない。各ページで自分自身を指すよう修正した。

### クローラがサイト内を辿れるようになる

**トップページの初期HTMLに `<a>` タグが1本も無かった。** グローバルメニューが `ssr: false` かつハンバーガーを押すまで `<Link>` が DOM に生成されない実装で、Googlebot はクリックしないため JS を実行しても到達できなかった。JS を実行しない AI クローラからは「配下ページが存在しない1ページサイト」に見えていた。

`<a>` タグ **0本 → 8本**（`/`・`/service`・`/service/issues`・`/#mission`・`/#about`・`/#contact`・ロゴ）。

### Googlebot に真っ黒な画面として見えていた問題

リッチリザルトテストのスクリーンショットで確認。ファーストビューのコピーがスクロール8%（PC）まで `opacity: 0` で、かつ絵はすべて WebGL（Googlebot の環境では描画されない）ため、**可視テキスト0文字のページ**として評価される状態だった。ヒーローのコピーをスクロール0から表示するようにした（フェードアウト側は変更なし）。

### UI の改善・修正

- **左上のロゴをクリックでページ先頭へ戻れるようにした**
- ロゴを `z-30` に。`MissionSection`(z-20) が全画面を覆うため CONTACT ではクリックが届いていなかった
- トップへ戻る処理を `smooth` → `auto` + `syncScrollLerp()` に。smooth では最下部から呼ぶと先頭に着かなかった
- グローバルナビから BLOG を一旦削除（`/blog` の修正が保留中のため、壊れたページへの導線を増やさない）

### 構造化データ・メタデータ

- `/service`・`/service/issues` に `BreadcrumbList`、`/service` の3メニューを `Service` として出力
- 下層3ページに個別OGP（従来は og:title / og:url がトップのものだった）
- JSON-LD の `contactPoint.url` が 404 の `/contact` を指していたので `/#contact` に修正
- JSON-LD の画像を実体不一致の `ogp.jpg`（1024×537）から `ogp.png`（1200×630）に修正
- title の屋号二重を解消（`/works` は 88 文字だった）
- トップの h1 が2個あり文書順で最初が「LOADING」だった問題を解消
- 404ページの robots 矛盾（`noindex` と `index, follow` の併記）と、トップを主張する canonical を解消
- sitemap の `lastModified` をビルド時刻から実際の更新日に変更

### 開発環境

- `.gitignore` に `.next-verify/` を追加。検証ビルドの成果物を biome が lint し `pnpm lint` が18,000件超で落ちていた

## 動作確認

- `pnpm lint` / `pnpm format` / `pnpm exec tsc --noEmit` / `next build` すべてエラー0件
- PR #197 で Vercel プレビューデプロイと `lint-and-build` が pass
- オーナーによるブラウザ実機確認済み（ヒーローの表示、ロゴからの復帰、3D描画、MISSION の点滅解消）
- 配信HTMLの全画面レイヤー（`fixed inset-0`）の構成が本番と一致することを確認

## リリースに含まれないもの

- **blog 関連の変更は含まない。** `/blog` の SSR 化は `feature/seo-blog-ssr-and-structured-data` に隔離済み（実装・検証は完了、ブログの方針決定待ち）
- チャットボット（`ChatWidget` / `feature/dify-chatbot-widget`）は差分に含まれない

## リリース後に確認すること

- リッチリザルトテストでトップページのスクリーンショットが黒くなくなったか
- Search Console の URL 検査で `/service` の「Google が選択した正規URL」が自分自身になるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cEywQ7DQHnauixa3NxTi6
