### PR TITLE
fix(perf): スマホでヒーロー表示時に起きていた layout shift（CLS 0.367）を解消

### DIFF
--- a/src/app/components/HomeClient.tsx
+++ b/src/app/components/HomeClient.tsx
@@ -1,7 +1,13 @@
 // src/app/components/HomeClient.tsx
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import {
+	useState,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useCallback,
+} from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import MissionSection, { type MissionSidebarHandle } from "./MissionSection";
@@ -56,7 +62,14 @@ export default function HomeClient() {
 	const targetScrollRef = useRef(0);
 	const currentScrollRef = useRef(0);
 
-	useEffect(() => {
+	// useEffect ではなく useLayoutEffect にすること。
+	// SSR の HTML は PC 用レイアウト（isMobile=false）で出力される。useEffect だと
+	// ブラウザが一度 PC 用で描画したあとにスマホ用へ切り替わり、その位置移動が
+	// layout shift として計上される（Lighthouse で CLS 0.367 を実測）。
+	// ヒーローのコピーを最初から表示するようにした（Googlebot 対策）ことで、
+	// それまで opacity:0 で隠れていたこの切り替えが見えるようになった。
+	// useLayoutEffect なら最初の描画の前に判定が終わるので、切り替え自体が起きない。
+	useLayoutEffect(() => {
 		const checkMobile = () => {
 			setIsMobile(window.innerWidth < 768);
 		};


### PR DESCRIPTION
## 概要

PR #197 でヒーローのコピーを最初から表示するようにしたことで、スマホで layout shift（CLS 0.367）が発生していた。修正する。

## 原因

`isMobile` の判定を `useEffect`（描画後）で行っていたため、SSR の HTML（PC用レイアウト）が一度描画されてからスマホ用に切り替わっていた。以前はその瞬間ヒーローが `opacity:0` だったので見えなかったが、最初から表示するようにしたことでこの切り替えが layout shift として計上されるようになった。

Lighthouse の layout-shifts 監査で、発生元が text1Ref のコンテナ（left/top/width/height がクラスごと切り替わる）であることを確認。

## 修正

`useLayoutEffect` に変更し、最初の描画の前に判定を終わらせる。React 19 ではサーバー側の警告は出ない。

## 動作確認

Lighthouse（スマホ・devtools throttling・ローカル本番ビルド）:

| | 修正前（本番） | 修正後 |
|---|---|---|
| CLS | **0.367** | **0** |
| LCP | 2.2s | 3.1s（計測ぶれの範囲） |
| TBT | 70ms | 80ms |

`pnpm lint` / `pnpm format` / `pnpm exec tsc --noEmit` / `next build` すべてエラー0件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142foqvxCLdeuk9AazYcGvu
